### PR TITLE
IMP kafka reader and writer + unittests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.1.0
 * Kafka reader and writer.
+* Kafka fixtures.
 
 ## 1.0.0
 * Initial open-source release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.0
+* Kafka reader and writer.
+
+## 1.0.0
+* Initial open-source release.
+
 ## 0.5.0
 * Add managed_table sugar for hql utils.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,76 +3,8 @@
 
 ## 1.0.0
 * Initial open-source release.
-
-## 0.5.0
-* Add managed_table sugar for hql utils.
-
-## 0.4.0
-* Add `parallelism` option for writers to control a load on data storages.
-
-## 0.3.2
-* Fix: hql.create_table works with decimal and date fields.
-
-## 0.3.1
-* Improvement: moved base test classes inside package for reuse in dependant packages.
-* Fix: when no partitioning specified for file system writer.
-* Fix: remove default values from cassandra reader.
-
-## 0.3.0
-* Add generic writer `write.by_url`.
-* Refactored `read.by_url`.
-
-## 0.2.1
-* Fix empty context initialization bug.
-
-## 0.2.0
-* Udfs could be specified in SparklyContext.
-* Removed default hardcoded jars (breaking change).
-
-## 0.1.13
-* Switch json to ujson
-
-## 0.1.12
-* Add support for CSV, Parquet and Hive Metastore tables in `sparkly.read.by_url`.
-
-## 0.1.11
-* More hql utils: replace_table, and get_all_table_properties
-
-## 0.1.10
-* Kafka reader
-
-## 0.1.9
-* Hql get_create_table_statement bug fixes when creating nested complex types
-
-## 0.1.8
-* Hql utils: create_table, get_all_tables, table_exists, get_table_property, set_table_property
-
-## 0.1.7
-* Fix: direct mapping data frame type to hql
-* Fix: backticking field names
-
-## 0.1.6
-* Fix: work with timestamp type in hql generator
-
-## 0.1.5
-* Generating hive CREATE TABLE by dataframe schema
-
-## 0.1.4
-* Read elastic parallelism parameter
-
-## 0.1.3
-* Read cassandra parallelism parameter
-
-## 0.1.2
-* Fix build to include resources
-* Remove cassandra gz from repo
-* Fix cassandra write consistency parameter
-
-## 0.1.1
-* Generic reader from_url
-* Integration testing
-* Mysql reader added
-
-## 0.1.0
-* Initial version: basic convenient functions and Sparkly context
-* Readers for elastic, cassandra, csv
+* Features:
+ - Convenient dependencies setup: packages, jars, UDFs.
+ - Reader and Writer unique interface: parquet, csv, mysql, cassandra, elastic.
+ - Hive metastore utils: properties operations, create table, replace table.
+ - Testing framework.

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ dev:
 	docker-compose run dev-spark-1.6 bash
 
 dist:
-	docker-compose build dev
+	docker-compose build dev-spark-1.6
 	docker-compose run --no-deps dev-spark-1.6 python3 setup.py bdist_wheel ; retcode="$$?" ; docker-compose down -v ; exit $$retcode
 
 docs:

--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,4 @@ test:
 	docker-compose build test-spark-1.6
 	docker-compose run test-spark-1.6 tox ; retcode="$$?" ; docker-compose down -v ; exit $$retcode
 
-.PHONY: docs
+.PHONY: docs dist

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
       KAFKA_ADVERTISED_PORT: 9092
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
       KAFKA_ZOOKEEPER_CONNECT: zookeeper.docker:2181
+      KAFKA_NUM_PARTITIONS: 3
     depends_on:
       - zookeeper.docker
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - cassandra.docker
       - elastic.docker
       - mysql.docker
+      - kafka.docker
 
   test-spark-1.6:
     build: .
@@ -15,10 +16,7 @@ services:
       - cassandra.docker
       - elastic.docker
       - mysql.docker
-    links:
-      - cassandra.docker
-      - elastic.docker
-      - mysql.docker
+      - kafka.docker
 
   cassandra.docker:
     image: cassandra:2.1.13
@@ -37,3 +35,20 @@ services:
       MYSQL_DATABASE: sparkly_test
       MYSQL_USER: root
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+
+  kafka.docker:
+    image: wurstmeister/kafka
+    expose:
+      - "9092"
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: kafka.docker
+      KAFKA_ADVERTISED_PORT: 9092
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper.docker:2181
+    depends_on:
+      - zookeeper.docker
+
+  zookeeper.docker:
+    image: wurstmeister/zookeeper
+    expose:
+      - "2181"

--- a/docs/source/reader_and_writer.rst
+++ b/docs/source/reader_and_writer.rst
@@ -151,12 +151,8 @@ the second covers a lack of writing functionality in the official distribution.
 | Configuration | http://spark.apache.org/docs/latest/streaming-kafka-0-10-integration.html                  |
 +---------------+--------------------------------------------------------------------------------------------+
 
-Features:
- - Autodiscover topic partitions and offsets.
- - Works with Dataframe Api for read and write.
-
 .. note::
-    - To use Kafka functionality **sparkly** needs the **kafka-python** library which is an optional dependency.
+    - To use the Kafka functionality **sparkly** needs the **kafka-python** library which is an optional dependency.
       So you need to install **sparkly** with **kafka** extras:
       ```
       pip install sparkly[kafka]
@@ -170,8 +166,8 @@ Features:
       ```
       df = ctx.createDataFrame(data, schema=schema)
       ```
-    - This was tested on Kafka version **0.10.x**, which is the most recent to the moment, was not tested on
-      Kafka **0.8.x** for which needs another package version, which do not have Api used in Sparkly.
+    - This functionality was tested on Kafka version **0.10.x**, which is the most recent to the moment.
+      It was not tested on Kafka **0.8.x** for which needs another package version, which does not have Api used in Sparkly.
 
 .. code-block:: python
 
@@ -213,7 +209,6 @@ Features:
         topic='my.topic',
         key_serializer=lambda item: json.dumps(item).encode('utf-8'),
         value_serializer=lambda item: json.dumps(item).encode('utf-8'),
-        schema=df_schema,  # the schema is defined above
     )
 
 .. _universal-reader-and-writer:

--- a/docs/source/reader_and_writer.rst
+++ b/docs/source/reader_and_writer.rst
@@ -135,6 +135,106 @@ Basically, it's just a high level api on top of the native
     df.write_ext.mysql('localhost', 'my_database', 'my_table',
                        options={'user': 'root', 'password': 'root'})
 
+.. _kafka:
+
+Kafka
+^^^^^
+
+Spark streaming Kafka package (`org.apache.spark:spark-streaming-kafka <https://mvnrepository.com/artifact/org.apache.spark/spark-streaming-kafka-0-10_2.11/2.0.0>`_)
+only provides a basic functionality to represent Kafka topics as RDDs.
+Sparkly provides a more convenient interface for both read and write to Kafka topics.
+This introduces a dependecy on `kafka-python <https://github.com/dpkp/kafka-python>`_ library.
+
++---------------+--------------------------------------------------------------------------------------------+
+| Package       | https://mvnrepository.com/artifact/org.apache.spark/spark-streaming-kafka-0-10_2.11/2.0.0  |
++---------------+--------------------------------------------------------------------------------------------+
+| Configuration | http://spark.apache.org/docs/latest/streaming-kafka-0-10-integration.html                  |
++---------------+--------------------------------------------------------------------------------------------+
+
+Features:
+ - Autodicover topic partitions and offsets.
+ - Work with both RDD and Dataframe for read and write.
+
+.. note::
+    - To use Kafka functionality **sparkly** needs the **kafka-python** library which is an optional dependency.
+      So you need to install **sparkly** with **kafka** extras:
+      ```
+      pip install sparkly[kafka]
+      ```
+    - When working via RDD api, it is expected to be organized as 2-element tuples, which are key and value:
+      ```
+      rdd = ctx._sc.parallelize([(key1, value1), (key2, value2>), ...])
+      ```
+    - When working via DataFrame api, it is expected to be organized as a structure with two top level keys
+      for key and value:
+      ```
+      schema=StructType([StructField('key', ...), StructField('value', ...)]))
+      ```
+      and then
+      ```
+      df = ctx.createDataFrame(data, schema=schema)
+      ```
+    - This was tested on Kafka version **0.10.x**, which is the most recent to the moment, was not tested on
+      Kafka **0.8.x** for which needs another package version, which do not have Api used in Sparkly.
+
+.. code-block:: python
+
+    import json
+    from sparkly import SparklyContext
+
+    class MyContext(SparklyContext):
+        packages = [
+            'org.apache.spark:spark-streaming-kafka_2.10:1.6.1',
+        ]
+
+    hc = MyContext()
+
+    # To read unstructured data from kafka in json as RDD.
+    rdd = hc.read_ext.kafka(
+        ['kafka.host:9092'],
+        topics=['my.topic'],
+        key_deserializer=lambda item: json.loads(item.decode('utf-8')),
+        value_deserializer=lambda item: json.loads(item.decode('utf-8')),
+    )
+
+    # To read structued data from kafka in json as Dataframe.
+
+    #   1. Define the schema of the data you read.
+    df_schema = StructType([
+        StructField('key', StructType([
+            StructField('id', StringType(), True)
+        ])),
+        StructField('value', StructType([
+            StructField('name', StringType(), True),
+            StructField('surname', StringType(), True),
+        ]))
+    ])
+
+    #   2. Specify the schema as the reader parameter.
+    df = hc.read_ext.kafka(
+        ['kafka.host:9092'],
+        topics=['my.topic'],
+        key_deserializer=lambda item: json.loads(item.decode('utf-8')),
+        value_deserializer=lambda item: json.loads(item.decode('utf-8')),
+        schema=df_schema,
+    )
+
+    # To write unstructured data to kafka in json from RDD
+    rdd.write_ext.kafka(
+        ['kafka.host:9092'],
+        topics=['my.topic'],
+        key_serializer=lambda item: json.dumps(item).encode('utf-8'),
+        value_serializer=lambda item: json.dumps(item).encode('utf-8'),
+    )
+
+    # To write structuctured data to kafka in json from Dataframe
+    df.write_ext.kafka(
+        ['kafka.host:9092'],
+        topics=['my.topic'],
+        key_serializer=lambda item: json.dumps(item).encode('utf-8'),
+        value_serializer=lambda item: json.dumps(item).encode('utf-8'),
+        schema=df_schema,  # the schema is defined above
+    )
 
 .. _universal-reader-and-writer:
 

--- a/docs/source/reader_and_writer.rst
+++ b/docs/source/reader_and_writer.rst
@@ -140,30 +140,26 @@ Basically, it's just a high level api on top of the native
 Kafka
 ^^^^^
 
-Spark streaming Kafka package (`org.apache.spark:spark-streaming-kafka <https://mvnrepository.com/artifact/org.apache.spark/spark-streaming-kafka-0-10_2.11/2.0.0>`_)
-only provides a basic functionality to represent Kafka topics as RDDs.
-Sparkly provides a more convenient interface for both read and write to Kafka topics.
-This introduces a dependecy on `kafka-python <https://github.com/dpkp/kafka-python>`_ library.
+Sparkly's reader and writer for Kafka are built on top of the official spark package
+for Kafka and python library `kafka-python <https://github.com/dpkp/kafka-python>`_ .
+The first one allows us to read data efficiently,
+the second covers a lack of writing functionality in the official distribution.
 
 +---------------+--------------------------------------------------------------------------------------------+
-| Package       | https://mvnrepository.com/artifact/org.apache.spark/spark-streaming-kafka-0-10_2.11/2.0.0  |
+| Package       | https://mvnrepository.com/artifact/org.apache.spark/spark-streaming-kafka_2.10             |
 +---------------+--------------------------------------------------------------------------------------------+
 | Configuration | http://spark.apache.org/docs/latest/streaming-kafka-0-10-integration.html                  |
 +---------------+--------------------------------------------------------------------------------------------+
 
 Features:
- - Autodicover topic partitions and offsets.
- - Work with both RDD and Dataframe for read and write.
+ - Autodiscover topic partitions and offsets.
+ - Works with Dataframe Api for read and write.
 
 .. note::
     - To use Kafka functionality **sparkly** needs the **kafka-python** library which is an optional dependency.
       So you need to install **sparkly** with **kafka** extras:
       ```
       pip install sparkly[kafka]
-      ```
-    - When working via RDD api, it is expected to be organized as 2-element tuples, which are key and value:
-      ```
-      rdd = ctx._sc.parallelize([(key1, value1), (key2, value2>), ...])
       ```
     - When working via DataFrame api, it is expected to be organized as a structure with two top level keys
       for key and value:
@@ -189,15 +185,7 @@ Features:
 
     hc = MyContext()
 
-    # To read unstructured data from kafka in json as RDD.
-    rdd = hc.read_ext.kafka(
-        ['kafka.host:9092'],
-        topics=['my.topic'],
-        key_deserializer=lambda item: json.loads(item.decode('utf-8')),
-        value_deserializer=lambda item: json.loads(item.decode('utf-8')),
-    )
-
-    # To read structued data from kafka in json as Dataframe.
+    # To read data from kafka in json as Dataframe.
 
     #   1. Define the schema of the data you read.
     df_schema = StructType([
@@ -212,25 +200,17 @@ Features:
 
     #   2. Specify the schema as the reader parameter.
     df = hc.read_ext.kafka(
-        ['kafka.host:9092'],
-        topics=['my.topic'],
+        'kafka.host',
+        topic='my.topic',
         key_deserializer=lambda item: json.loads(item.decode('utf-8')),
         value_deserializer=lambda item: json.loads(item.decode('utf-8')),
         schema=df_schema,
     )
 
-    # To write unstructured data to kafka in json from RDD
-    rdd.write_ext.kafka(
-        ['kafka.host:9092'],
-        topics=['my.topic'],
-        key_serializer=lambda item: json.dumps(item).encode('utf-8'),
-        value_serializer=lambda item: json.dumps(item).encode('utf-8'),
-    )
-
-    # To write structuctured data to kafka in json from Dataframe
+    # To write data to kafka in json from Dataframe
     df.write_ext.kafka(
-        ['kafka.host:9092'],
-        topics=['my.topic'],
+        'kafka.host',
+        topic='my.topic',
         key_serializer=lambda item: json.dumps(item).encode('utf-8'),
         value_serializer=lambda item: json.dumps(item).encode('utf-8'),
         schema=df_schema,  # the schema is defined above

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-kafka-python==1.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+kafka-python==1.2.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,3 +5,4 @@ Sphinx==1.4.6
 sphinx_rtd_theme==0.1.9
 cassandra-driver==3.7.1
 PyMySQL==0.7.9
+kafka-python==1.2.2

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -7,4 +7,5 @@ Sphinx==1.4.6
 sphinx_rtd_theme==0.1.9
 cassandra-driver==3.7.1
 PyMySQL==0.7.9
+kafka-python==1.2.2
 -e git+https://github.com/Tubular/spark@fix/python27-support#egg=pyspark&subdirectory=python

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,6 @@ setup(
     install_requires=reqs,
     extras_require={
         'kafka': ['kafka-python>=1.2.2,<1.3'],
-        'test': ['cassandra-driver>=3.7,<3.8', 'PyMySQL>=0.7,<0.8'],
+        'test': ['cassandra-driver>=3.7,<3.8', 'PyMySQL>=0.7,<0.8', 'kafka-python>=1.2.2,<1.3'],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.0.0',
+    version='1.1.0',
 
     description='Helpers & syntax sugar for PySpark.',
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=reqs,
     extras_require={
+        'kafka': ['kafka-python>=1.2.2,<1.3'],
         'test': ['cassandra-driver>=3.7,<3.8', 'PyMySQL>=0.7,<0.8'],
     },
 )

--- a/sparkly/exceptions.py
+++ b/sparkly/exceptions.py
@@ -10,3 +10,7 @@ class UnsupportedDataType(SparklyException):
 class FixtureError(SparklyException):
     """Happen when testing data setup or teardown fails."""
     pass
+
+
+class InvalidArgumentError(SparklyException):
+    """Happen when invalide parameters passed to the function."""

--- a/sparkly/testing.py
+++ b/sparkly/testing.py
@@ -117,16 +117,6 @@ class SparklyTest(TestCase):
             except AttributeError:
                 self.assertItemsEqual(actual_data, expected_data)
 
-    def assertRDDEqual(self, actual_rdd, expected_data, ordered=False):
-        actual_data = actual_rdd.collect() if hasattr(actual_rdd, 'collect') else actual_rdd
-        if ordered:
-            self.assertEqual(actual_data, expected_data)
-        else:
-            try:
-                self.assertCountEqual(actual_data, expected_data)
-            except AttributeError:
-                self.assertItemsEqual(actual_data, expected_data)
-
 
 class SparklyGlobalContextTest(SparklyTest):
     """Base test case that keeps a single instance for the given context class across all tests.

--- a/sparkly/testing.py
+++ b/sparkly/testing.py
@@ -26,6 +26,11 @@ except ImportError:
     except:
         pass
 
+try:
+    from kafka import KafkaProducer
+except ImportError:
+    pass
+
 
 logger = logging.getLogger()
 
@@ -316,7 +321,7 @@ class ElasticFixture(Fixture):
 
 
 class MysqlFixture(Fixture):
-    """Base test class for mysql integration tests.
+    """Fixture for mysql integration tests.
 
     Notes:
      * depends on PyMySql lib.
@@ -356,3 +361,63 @@ class MysqlFixture(Fixture):
 
     def teardown_data(self):
         self._execute(self.read_file(self.teardown))
+
+
+class KafkaFixture(Fixture):
+    """Fixture for kafka integration tests.
+
+    Notes:
+     * depends on kafka-python lib.
+     * json file should contain array of dicts: [{'key': ..., 'value': ...}]
+
+    Examples:
+
+        >>> class MyTestCase(SparklyContext):
+        ...     fixtures = [
+        ...         KafkaFixture(
+        ...             'kafka.host', 'topic',
+        ...             key_serializer=..., value_serializer=...,
+        ...             data='/path/to/data.json',
+        ...         )
+        ...     ]
+
+    """
+    def __init__(self, host, port=9092, topic=None,
+                 key_serializer=None, value_serializer=None,
+                 data=None):
+        """Constructor.
+
+        Args:
+            host (str): Kafka host.
+            port (int): Kafka port.
+            topic (str): Kafka topic.
+            key_serializer (function): Converts python data structure to bytes,
+                applied to message key.
+            value_serializer (function): Converts python data structure to bytes,
+                applied to message value.
+            data (str): Path to json file with data.
+        """
+
+        self.host = host
+        self.port = port
+        self.topic = topic
+        self.key_serializer = key_serializer
+        self.value_serializer = value_serializer
+        self.data = data
+
+    def _publish_data(self, data):
+        producer = KafkaProducer(bootstrap_servers='kafka.docker',
+                                 key_serializer=self.key_serializer,
+                                 value_serializer=self.value_serializer)
+        for item in data:
+            producer.send(self.topic, key=item['key'], value=item['value'])
+
+        producer.flush()
+        producer.close()
+
+    def setup_data(self):
+        data = [json.loads(item) for item in self.read_file(self.data).strip().split('\n')]
+        self._publish_data(data)
+
+    def teardown_data(self):
+        pass

--- a/sparkly/utils.py
+++ b/sparkly/utils.py
@@ -38,34 +38,34 @@ def absolute_path(file_path, *rel_path):
     )
 
 
-def kafka_get_topics_offsets(brokers, topics):
+def kafka_get_topics_offsets(host, topic, port=None):
     """Returns available partitions and its offsets for list of topics.
 
     Args:
-        brokers (list): List of kafka brokers.
-        topics (list): List of topics.
+        host (str): Kafka host.
+        topic (str): Kafka topic.
+        port (int|None): Kafka port.
     Returns:
-        [(str, str, int, int)]: [(topic, partition, start_offset, end_offset)].
+        [(int, int, int)]: [(partition, start_offset, end_offset)].
     """
+    brokers = ['{}:{}'.format(host, port or 9092)]
     client = SimpleClient(brokers)
 
     offsets = []
-    for topic in topics:
-        partitions = client.get_partition_ids_for_topic(topic)
+    partitions = client.get_partition_ids_for_topic(topic)
 
-        offsets_responses_end = client.send_offset_request(
-            [OffsetRequestPayload(topic, partition, -1, 1)
-             for partition in partitions]
-        )
-        offsets_responses_start = client.send_offset_request(
-            [OffsetRequestPayload(topic, partition, -2, 1)
-             for partition in partitions]
-        )
+    offsets_responses_end = client.send_offset_request(
+        [OffsetRequestPayload(topic, partition, -1, 1)
+         for partition in partitions]
+    )
+    offsets_responses_start = client.send_offset_request(
+        [OffsetRequestPayload(topic, partition, -2, 1)
+         for partition in partitions]
+    )
 
-        for start_offset, end_offset in zip(offsets_responses_start, offsets_responses_end):
-            offsets.append((topic,
-                            start_offset.partition,
-                            start_offset.offsets[0],
-                            end_offset.offsets[0]))
+    for start_offset, end_offset in zip(offsets_responses_start, offsets_responses_end):
+        offsets.append((start_offset.partition,
+                        start_offset.offsets[0],
+                        end_offset.offsets[0]))
 
     return offsets

--- a/sparkly/utils.py
+++ b/sparkly/utils.py
@@ -38,17 +38,18 @@ def absolute_path(file_path, *rel_path):
     )
 
 
-def kafka_get_topics_offsets(host, topic, port=None):
-    """Returns available partitions and its offsets for list of topics.
+def kafka_get_topics_offsets(host, topic, port=9092):
+    """Returns available partitions and their offsets for the given topic.
 
     Args:
         host (str): Kafka host.
         topic (str): Kafka topic.
-        port (int|None): Kafka port.
+        port (int): Kafka port.
+
     Returns:
         [(int, int, int)]: [(partition, start_offset, end_offset)].
     """
-    brokers = ['{}:{}'.format(host, port or 9092)]
+    brokers = ['{}:{}'.format(host, port)]
     client = SimpleClient(brokers)
 
     offsets = []

--- a/sparkly/writer.py
+++ b/sparkly/writer.py
@@ -202,28 +202,34 @@ class SparklyWriter(object):
               topic,
               key_serializer,
               value_serializer,
-              port=None,
+              port=9092,
               parallelism=None,
               options=None):
-        """Writes dataframge to kafka topic.
+        """Writes dataframe to kafka topic.
 
-        Expected schema is:
-          key -> Struct(...)
-          value -> Struct(...)
+        The schema of the dataframe should conform the pattern:
+
+        >>>  StructType([
+        ...     StructField('key', ...),
+        ...     StructField('value', ...),
+        ...  ])
+
+        Parameters `key_serializer` and `value_serializer` are callables
+        which get's python structure as input and should return bytes of encoded data as output.
 
         Args:
             host (str): Kafka host.
             topic (str): Topic to write to.
             key_serializer (function): Function to serialize key.
             value_serializer (function): Function to serialize value.
-            port (int|None): Kafka port.
+            port (int): Kafka port.
             parallelism (int|None): The max number of parallel tasks that could be executed
                 during the write stage (see :ref:`controlling-the-load`).
             options (dict|None): Additional options.
         """
         def write_partition_to_kafka(messages):
             producer = KafkaProducer(
-                bootstrap_servers=['{}:{}'.format(host, port or 9092)],
+                bootstrap_servers=['{}:{}'.format(host, port)],
                 key_serializer=key_serializer,
                 value_serializer=value_serializer,
             )

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -9,6 +9,7 @@ class _TestContext(SparklyContext):
         'com.databricks:spark-csv_2.10:1.4.0',
         'datastax:spark-cassandra-connector:1.6.1-s_2.10',
         'org.elasticsearch:elasticsearch-spark_2.10:2.3.0',
+        'org.apache.spark:spark-streaming-kafka_2.10:1.6.1',
     ]
 
     jars = [

--- a/tests/integration/resources/test_fixtures/kafka.json
+++ b/tests/integration/resources/test_fixtures/kafka.json
@@ -1,0 +1,5 @@
+{"key": {"name": "johny"}, "value": {"name": "johny", "surname": "cage"}}
+{"key": {"name": "johny"}, "value": {"name": "johny", "surname": "smith"}}
+{"key": {"name": "aron"}, "value": {"name": "aron", "surname": "ramsey"}}
+{"key": {"name": "killy"}, "value": {"name": "killy", "surname": "gonsales"}}
+{"key": {"name": "shefkey"}, "value": {"name": "shefkey", "surname": "kuki"}}

--- a/tests/integration/resources/test_read/kafka_setup.json
+++ b/tests/integration/resources/test_read/kafka_setup.json
@@ -1,0 +1,12 @@
+{"key": {"name": "john"}, "value": {"name": "john", "surname": "smith", "age": 1}}
+{"key": {"name": "john"}, "value": {"name": "john", "surname": "smith", "age": 2}}
+{"key": {"name": "john"}, "value": {"name": "john", "surname": "mnemonic", "age": 3}}
+{"key": {"name": "john"}, "value": {"name": "john", "surname": "mnemonic", "age": 4}}
+{"key": {"name": "john"}, "value": {"name": "john", "surname": "smith", "age": 5}}
+{"key": {"name": "john"}, "value": {"name": "john", "surname": "smith", "age": 6}}
+{"key": {"name": "john"}, "value": {"name": "john", "surname": "mnemonic", "age": 7}}
+{"key": {"name": "john"}, "value": {"name": "john", "surname": "mnemonic", "age": 8}}
+{"key": {"name": "john"}, "value": {"name": "john", "surname": "smith", "age": 9}}
+{"key": {"name": "john"}, "value": {"name": "john", "surname": "smith", "age": 10}}
+{"key": {"name": "john"}, "value": {"name": "john", "surname": "mnemonic", "age": 11}}
+{"key": {"name": "john"}, "value": {"name": "john", "surname": "mnemonic", "age": 12}}

--- a/tests/integration/resources/test_write/kafka_setup.json
+++ b/tests/integration/resources/test_write/kafka_setup.json
@@ -1,0 +1,12 @@
+{"key": {"name": "john"}, "value": {"name": "john", "surname": "smith", "age": 1}}
+{"key": {"name": "john"}, "value": {"name": "john", "surname": "smith", "age": 2}}
+{"key": {"name": "john"}, "value": {"name": "john", "surname": "mnemonic", "age": 3}}
+{"key": {"name": "john"}, "value": {"name": "john", "surname": "mnemonic", "age": 4}}
+{"key": {"name": "john"}, "value": {"name": "john", "surname": "smith", "age": 5}}
+{"key": {"name": "john"}, "value": {"name": "john", "surname": "smith", "age": 6}}
+{"key": {"name": "john"}, "value": {"name": "john", "surname": "mnemonic", "age": 7}}
+{"key": {"name": "john"}, "value": {"name": "john", "surname": "mnemonic", "age": 8}}
+{"key": {"name": "john"}, "value": {"name": "john", "surname": "smith", "age": 9}}
+{"key": {"name": "john"}, "value": {"name": "john", "surname": "smith", "age": 10}}
+{"key": {"name": "john"}, "value": {"name": "john", "surname": "mnemonic", "age": 11}}
+{"key": {"name": "john"}, "value": {"name": "john", "surname": "mnemonic", "age": 12}}

--- a/tests/integration/test_testing.py
+++ b/tests/integration/test_testing.py
@@ -35,14 +35,6 @@ class TestAssertions(SparklyGlobalContextTest):
                 ordered=True,
             )
 
-    def test_assert_rdd_equal(self):
-        rdd = self.hc._sc.parallelize([1, 2, 3, 4, 5])
-
-        self.assertRDDEqual(rdd, [1, 2, 3, 4, 5])
-        self.assertRDDEqual(rdd, [1, 2, 3, 4, 5], ordered=True)
-        with self.assertRaises(AssertionError):
-            self.assertRDDEqual(rdd, [3, 4, 5, 1, 2], ordered=True)
-
 
 class TestCassandraFixtures(SparklyGlobalContextTest):
     context = _TestContext

--- a/tests/integration/test_testing.py
+++ b/tests/integration/test_testing.py
@@ -1,5 +1,3 @@
-import pytest
-
 from sparkly.testing import (
     CassandraFixture,
     ElasticFixture,
@@ -8,6 +6,42 @@ from sparkly.testing import (
 )
 from sparkly.utils import absolute_path
 from tests.integration.base import _TestContext
+
+
+class TestAssertions(SparklyGlobalContextTest):
+    context = _TestContext
+
+    def test_assert_dataframe_equal(self):
+        df = self.hc.createDataFrame([('Alice', 1),
+                                      ('Kelly', 1),
+                                      ('BigBoss', 999)],
+                                     ['name', 'age'])
+        self.assertDataFrameEqual(
+            df,
+            [{'name': 'Alice', 'age': 1},
+             {'name': 'BigBoss', 'age': 999},
+             {'name': 'Kelly', 'age': 1},
+             ],
+            ordered=False,
+        )
+
+        with self.assertRaises(AssertionError):
+            self.assertDataFrameEqual(
+                df,
+                [{'name': 'Alice', 'age': 1},
+                 {'name': 'BigBoss', 'age': 999},
+                 {'name': 'Kelly', 'age': 1},
+                 ],
+                ordered=True,
+            )
+
+    def test_assert_rdd_equal(self):
+        rdd = self.hc._sc.parallelize([1, 2, 3, 4, 5])
+
+        self.assertRDDEqual(rdd, [1, 2, 3, 4, 5])
+        self.assertRDDEqual(rdd, [1, 2, 3, 4, 5], ordered=True)
+        with self.assertRaises(AssertionError):
+            self.assertRDDEqual(rdd, [3, 4, 5, 1, 2], ordered=True)
 
 
 class TestCassandraFixtures(SparklyGlobalContextTest):

--- a/tests/integration/test_testing.py
+++ b/tests/integration/test_testing.py
@@ -1,11 +1,19 @@
+import json
+import uuid
+
 from sparkly.testing import (
     CassandraFixture,
     ElasticFixture,
     MysqlFixture,
     SparklyGlobalContextTest,
-)
+    KafkaFixture)
 from sparkly.utils import absolute_path
 from tests.integration.base import _TestContext
+
+try:
+    from kafka import KafkaConsumer
+except ImportError:
+    pass
 
 
 class TestAssertions(SparklyGlobalContextTest):
@@ -97,3 +105,39 @@ class TestElasticFixture(SparklyGlobalContextTest):
         self.assertDataFrameEqual(df, [
             {'name': 'John', 'age': 56},
         ])
+
+
+class TestKafkaFixture(SparklyGlobalContextTest):
+
+    context = _TestContext
+
+    topic = 'sparkly.test.fixture.{}'.format(uuid.uuid4().hex[:10])
+    fixtures = [
+        KafkaFixture(
+            'kafka.docker',
+            topic=topic,
+            key_serializer=lambda item: json.dumps(item).encode('utf-8'),
+            value_serializer=lambda item: json.dumps(item).encode('utf-8'),
+            data=absolute_path(__file__, 'resources', 'test_fixtures', 'kafka.json'),
+        )
+    ]
+
+    def test_kafka_fixture(self):
+        consumer = KafkaConsumer(
+            self.topic,
+            bootstrap_servers='kafka.docker:9092',
+            key_deserializer=lambda item: json.loads(item.decode('utf-8')),
+            value_deserializer=lambda item: json.loads(item.decode('utf-8')),
+            auto_offset_reset='earliest',
+        )
+
+        actual_data = []
+        for i in range(5):
+            message = next(consumer)
+            data = {'key': message.key, 'value': message.value}
+            actual_data.append(data)
+
+        expected_data = self.hc.read.json(
+            absolute_path(__file__, 'resources', 'test_fixtures', 'kafka.json')
+        )
+        self.assertDataFrameEqual(expected_data, actual_data)

--- a/tests/integration/test_writer.py
+++ b/tests/integration/test_writer.py
@@ -3,6 +3,8 @@ import uuid
 from shutil import rmtree
 from tempfile import mkdtemp
 
+from pyspark.sql.types import StructType, StructField, StringType, IntegerType
+
 from sparkly.utils import absolute_path
 from sparkly.testing import (
     SparklyGlobalContextTest,
@@ -149,39 +151,69 @@ class TestWriteKafka(SparklyGlobalContextTest):
     context = _TestContext
 
     KAFKA_TEST_DATA = [
-        ({'name': 'john'}, {'name': 'john', 'surname': 'smith'}),
-        ({'name': 'john'}, {'name': 'john', 'surname': 'mnemonic'}),
-        ({'name': 'kelly'}, {'name': 'kelly', 'surname': 'smith'}),
-        ({'name': 'john'}, {'name': 'john', 'surname': 'smith'}),
-        ({'name': 'john'}, {'name': 'john', 'surname': 'mnemonic'}),
-        ({'name': 'kelly'}, {'name': 'kelly', 'surname': 'smith'}),
-        ({'name': 'john'}, {'name': 'john', 'surname': 'smith'}),
-        ({'name': 'john'}, {'name': 'john', 'surname': 'mnemonic'}),
-        ({'name': 'kelly'}, {'name': 'kelly', 'surname': 'smith'}),
+        ({'name': 'john'}, {'name': 'john', 'surname': 'smith', 'age': 1}),
+        ({'name': 'john'}, {'name': 'john', 'surname': 'mnemonic', 'age': 2}),
+        ({'name': 'kelly'}, {'name': 'kelly', 'surname': 'smith', 'age': 3}),
+        ({'name': 'john'}, {'name': 'john', 'surname': 'smith', 'age': 4}),
+        ({'name': 'john'}, {'name': 'john', 'surname': 'mnemonic', 'age': 5}),
+        ({'name': 'kelly'}, {'name': 'kelly', 'surname': 'smith', 'age': 6}),
+        ({'name': 'john'}, {'name': 'john', 'surname': 'smith', 'age': 7}),
+        ({'name': 'john'}, {'name': 'john', 'surname': 'mnemonic', 'age': 8}),
+        ({'name': 'kelly'}, {'name': 'kelly', 'surname': 'smith', 'age': 9}),
     ]
 
-    def test_write_kafka(self):
-        topic = 'test.topic.write.kafka.{}'.format(uuid.uuid4().hex[:10])
+    def setUp(self):
+        self.json_decoder = lambda item: json.loads(item.decode('utf-8'))
+        self.json_encoder = lambda item: json.dumps(item).encode('utf-8')
+        self.topic = 'test.topic.write.kafka.{}'.format(uuid.uuid4().hex[:10])
 
-        def _json_decoder(item):
-            return json.loads(item.decode('utf-8'))
-
-        def _json_encoder(item):
-            return json.dumps(item).encode('utf-8')
-
+    def test_write_kafka_dataframe(self):
         rdd = self.hc._sc.parallelize(self.KAFKA_TEST_DATA)
 
-        rdd.write_ext.kafka(
-            ['kafka.docker:9092'], topic,
-            key_serializer=_json_encoder,
-            value_serializer=_json_encoder,
+        df_schema = StructType([
+            StructField('key', StructType([
+                StructField('name', StringType(), True)
+            ])),
+            StructField('value', StructType([
+                StructField('name', StringType(), True),
+                StructField('surname', StringType(), True),
+                StructField('age', IntegerType(), True),
+            ]))
+        ])
+
+        df = self.hc.createDataFrame(rdd, schema=df_schema)
+
+        df.write_ext.kafka(
+            ['kafka.docker:9092'],
+            self.topic,
+            key_serializer=self.json_encoder,
+            value_serializer=self.json_encoder,
         )
 
         rdd = self.hc.read_ext.kafka(
             ['kafka.docker:9092'],
-            topics=[topic],
-            key_deserializer=_json_decoder,
-            value_deserializer=_json_decoder,
+            topics=[self.topic],
+            key_deserializer=self.json_decoder,
+            value_deserializer=self.json_decoder,
+        )
+
+        self.assertRDDEqual(rdd, self.KAFKA_TEST_DATA)
+
+    def test_write_kafka_rdd(self):
+        rdd = self.hc._sc.parallelize(self.KAFKA_TEST_DATA)
+
+        rdd.write_ext.kafka(
+            ['kafka.docker:9092'],
+            self.topic,
+            key_serializer=self.json_encoder,
+            value_serializer=self.json_encoder,
+        )
+
+        rdd = self.hc.read_ext.kafka(
+            ['kafka.docker:9092'],
+            topics=[self.topic],
+            key_deserializer=self.json_decoder,
+            value_deserializer=self.json_decoder,
         )
 
         self.assertRDDEqual(rdd, self.KAFKA_TEST_DATA)

--- a/tests/integration/test_writer.py
+++ b/tests/integration/test_writer.py
@@ -152,6 +152,12 @@ class TestWriteKafka(SparklyGlobalContextTest):
         ({'name': 'john'}, {'name': 'john', 'surname': 'smith'}),
         ({'name': 'john'}, {'name': 'john', 'surname': 'mnemonic'}),
         ({'name': 'kelly'}, {'name': 'kelly', 'surname': 'smith'}),
+        ({'name': 'john'}, {'name': 'john', 'surname': 'smith'}),
+        ({'name': 'john'}, {'name': 'john', 'surname': 'mnemonic'}),
+        ({'name': 'kelly'}, {'name': 'kelly', 'surname': 'smith'}),
+        ({'name': 'john'}, {'name': 'john', 'surname': 'smith'}),
+        ({'name': 'john'}, {'name': 'john', 'surname': 'mnemonic'}),
+        ({'name': 'kelly'}, {'name': 'kelly', 'surname': 'smith'}),
     ]
 
     def test_write_kafka(self):
@@ -173,7 +179,7 @@ class TestWriteKafka(SparklyGlobalContextTest):
 
         rdd = self.hc.read_ext.kafka(
             ['kafka.docker:9092'],
-            [[topic, 0, 0, 3]],
+            topics=[topic],
             key_deserializer=_json_decoder,
             value_deserializer=_json_decoder,
         )


### PR DESCRIPTION
# WHY
We want publish to and consume from kafka in spark jobs

# HOW
 - Use streaming kafka package to create RDD and DataFrame on top of kafka topics
 - Use python-kafka to publish from executors to kafka

# WHAT
Example for json serializer
```
df = hc.createDataFrame(...)
df.write_ext.kafka(
   'kafka.host', topic,
   key_serializer=_json_encoder,
   value_serializer=_json_encoder,
)

df = ctx.read_ext.kafka(
    'kafka.host',
    topic,
    key_deserializer=_json_decoder,
    value_deserializer=_json_decoder,
    schema=StructType(...)
)
```