### PR TITLE
FIX bump minor version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.0
+## 2.0.1
 * Migrate to Spark 2, Spark 1.6.x isn't supported by sparkly 2.x. 
 * Rename `SparklyContext` to `SparklySession` and derive it from `SparkSession`.
 * Use built-in csv reader.

--- a/sparkly/__init__.py
+++ b/sparkly/__init__.py
@@ -19,4 +19,4 @@ from sparkly.session import SparklySession
 assert SparklySession
 
 
-__version__ = '2.0.0'
+__version__ = '2.0.1'


### PR DESCRIPTION
I messed up and published `sparkly` with broken `setup.py` on python3.5 env.
Let's increment patch version and remove `2.0.0` from the pypi.