### PR TITLE
Imp/add kafkawatcher context manager for testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.3
+* Add KafkaWatcher to facilitate testing of writing to Kafka
+* Fix a few minor pyflakes warnings and typos
+
 ## 2.0.2
 * Fix: #40 write_ext.kafka ignores errors.
 

--- a/sparkly/__init__.py
+++ b/sparkly/__init__.py
@@ -19,4 +19,4 @@ from sparkly.session import SparklySession
 assert SparklySession
 
 
-__version__ = '2.0.2'
+__version__ = '2.0.3'

--- a/sparkly/catalog.py
+++ b/sparkly/catalog.py
@@ -14,12 +14,6 @@
 # limitations under the License.
 #
 
-import logging
-import re
-
-from pyspark.sql import DataFrame
-from pyspark.sql.types import StructType
-
 
 class SparklyCatalog(object):
     """A set of tools to interact with HiveMetastore."""

--- a/sparkly/reader.py
+++ b/sparkly/reader.py
@@ -233,7 +233,7 @@ class SparklyReader(object):
         `key` and `value`.
 
         Parameters `key_deserializer` and `value_deserializer` are callables
-        which get's bytes as input and should return python structures as output.
+        which get bytes as input and should return python structures as output.
 
         Args:
             host (str): Kafka host.

--- a/sparkly/utils.py
+++ b/sparkly/utils.py
@@ -14,10 +14,9 @@
 # limitations under the License.
 #
 
-from collections import OrderedDict
+import inspect
 import os
 import re
-import inspect
 
 try:
     from kafka import SimpleClient

--- a/tests/integration/resources/test_testing/kafka_watcher_1.json
+++ b/tests/integration/resources/test_testing/kafka_watcher_1.json
@@ -1,0 +1,4 @@
+{"key": {"user_id": 1}, "value": {"meal": "dinner", "food": ["spaghetti", "meatballs"]}}
+{"key": {"user_id": 2}, "value": {"meal": "lunch", "food": ["soylent"]}}
+{"key": {"user_id": 3}, "value": {"meal": "breakfast", "food": []}}
+{"key": {"user_id": 2}, "value": {"meal": "second dinner", "food": ["galbi", "ice cream"]}}

--- a/tests/integration/resources/test_testing/kafka_watcher_2.json
+++ b/tests/integration/resources/test_testing/kafka_watcher_2.json
@@ -1,0 +1,3 @@
+{"key": {"user_id": 1}, "value": {"meal": "lunch", "food": ["pizza", "stinky tofu"]}}
+{"key": {"user_id": 4}, "value": {"meal": "lunch", "food": ["cuban sandwich", "mashed potatoes"]}}
+{"key": {"user_id": 5}, "value": {"meal": "dessert", "food": ["pecan pie", "mango"]}}

--- a/tests/integration/test_catalog.py
+++ b/tests/integration/test_catalog.py
@@ -14,9 +14,6 @@
 # limitations under the License.
 #
 
-import uuid
-import os
-
 from sparkly.testing import SparklyGlobalSessionTest
 from tests.integration.base import SparklyTestSession
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -16,7 +16,6 @@
 
 from unittest import TestCase
 
-from sparkly.exceptions import UnsupportedDataType
 from sparkly.utils import parse_schema
 
 


### PR DESCRIPTION
This context manager can be used to make it easier to test
Spark jobs that write to Kafka.

Also cleaned up a few pyflakes warnings.