### PR TITLE
FIX make it possible to override spark.sql.catalogImplementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.4
+* Make it possible to override default value of spark.sql.catalogImplementation
+
 ## 2.0.3
 * Add KafkaWatcher to facilitate testing of writing to Kafka
 * Fix a few minor pyflakes warnings and typos

--- a/sparkly/__init__.py
+++ b/sparkly/__init__.py
@@ -19,4 +19,4 @@ from sparkly.session import SparklySession
 assert SparklySession
 
 
-__version__ = '2.0.3'
+__version__ = '2.0.4'

--- a/sparkly/session.py
+++ b/sparkly/session.py
@@ -74,8 +74,8 @@ class SparklySession(SparkSession):
 
         # Init SparkContext
         spark_conf = SparkConf()
-        spark_conf.setAll(self._setup_options(additional_options))
         spark_conf.set('spark.sql.catalogImplementation', 'hive')
+        spark_conf.setAll(self._setup_options(additional_options))
         spark_context = SparkContext(conf=spark_conf)
 
         # Init HiveContext


### PR DESCRIPTION
Right now the setting is enforced after the user's setting and essentially
overriding them.

I have discovered that setting this to in-memory saves ~20 seconds (!) of
initialization time for SparklySession.