### PR TITLE
IMP migrate useful internal features 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Add implicit test target import and extended assertEqual variation
 * Support writing to redis:// and rediss:// URLs
 * Add LRU cache that persists DataFrames under the hood
+* Add ability to check whether a complex type defines specific fields
 
 # 2.2.1
 * `spark.sql.shuffle.partitions` in `SparklyTest` should be set to string,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.3.0
+* Overwrite existing tables in the metastore
+
 # 2.2.1
 * `spark.sql.shuffle.partitions` in `SparklyTest` should be set to string,
 because `int` value breaks integration testing in Spark 2.0.2. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.3.0
 * Overwrite existing tables in the metastore
-* Add functions module and provide switch_case column generation
+* Add functions module and provide switch_case column generation and multijoin
 
 # 2.2.1
 * `spark.sql.shuffle.partitions` in `SparklyTest` should be set to string,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Add functions module and provide switch_case column generation and multijoin
 * Add implicit test target import and extended assertEqual variation
 * Support writing to redis:// and rediss:// URLs
+* Add LRU cache that persists DataFrames under the hood
 
 # 2.2.1
 * `spark.sql.shuffle.partitions` in `SparklyTest` should be set to string,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Overwrite existing tables in the metastore
 * Add functions module and provide switch_case column generation and multijoin
 * Add implicit test target import and extended assertEqual variation
+* Support writing to redis:// and rediss:// URLs
 
 # 2.2.1
 * `spark.sql.shuffle.partitions` in `SparklyTest` should be set to string,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.3.0
 * Overwrite existing tables in the metastore
+* Add functions module and provide switch_case column generation
 
 # 2.2.1
 * `spark.sql.shuffle.partitions` in `SparklyTest` should be set to string,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.3.0
 * Overwrite existing tables in the metastore
 * Add functions module and provide switch_case column generation and multijoin
+* Add implicit test target import and extended assertEqual variation
 
 # 2.2.1
 * `spark.sql.shuffle.partitions` in `SparklyTest` should be set to string,

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,8 @@ ENV SPARK_HOME "/usr/local/spark/"
 ENV PYTHONPATH "/usr/local/spark/python/lib/pyspark.zip:/usr/local/spark/python/lib/py4j-0.10.4-src.zip:/opt/sparkly"
 ENV SPARK_TESTING true
 
-# Install Python testing utils
-RUN apt-get update && apt-get install -y python python3-pip
+# Install Python development & testing utils
+RUN apt-get update && apt-get install -y python python-dev python3-pip
 RUN python3 -m pip install tox==2.4.1
 
 # Remove noisy spark logging

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
         condition: service_healthy
       mysql.docker:
         condition: service_healthy
+      redis.docker:
+        condition: service_healthy
     volumes:
       - .:/opt/sparkly/
 
@@ -40,6 +42,8 @@ services:
       kafka.docker:
         condition: service_healthy
       mysql.docker:
+        condition: service_healthy
+      redis.docker:
         condition: service_healthy
 
   cassandra.docker:
@@ -81,6 +85,13 @@ services:
       KAFKA_NUM_PARTITIONS: 3
     healthcheck:
       test: ps ax | grep kafka
+
+  redis.docker:
+    image: redis:3.2.4
+    expose:
+      - 6379
+    healthcheck:
+      test: ps ax | grep redis
 
   zookeeper.docker:
     image: confluent/zookeeper

--- a/docs/source/catalog.rst
+++ b/docs/source/catalog.rst
@@ -31,7 +31,7 @@ or set it dynamically via ``SparklySession`` options:
 Tables management
 -----------------
 
-**Why:** sometimes you need more than just to create a table.
+**Why:** you need to check if tables exist, rename them, drop them, or even overwrite existing aliases in your catalog.
 
 .. code-block:: python
 
@@ -42,6 +42,7 @@ Tables management
 
     assert spark.catalog_ext.has_table('my_table') in {True, False}
     spark.catalog_ext.rename_table('my_table', 'my_new_table')
+    spark.catalog_ext.create_table('my_new_table', path='s3://my/parquet/data', source='parquet', mode='overwrite')
     spark.catalog_ext.drop_table('my_new_table')
 
 Table properties management

--- a/docs/source/functions.rst
+++ b/docs/source/functions.rst
@@ -1,7 +1,10 @@
-Column Functions
-================
+Column and DataFrame Functions
+==============================
 
-A counterpart of pyspark.sql.functions providing useful shortcuts, like a cleaner alternative to chaining together multiple when/otherwise statements.
+A counterpart of pyspark.sql.functions providing useful shortcuts:
+
+- a cleaner alternative to chaining together multiple when/otherwise statements.
+- an easy way to join multiple dataframes at once and disambiguate fields with the same name.
 
 
 API documentation

--- a/docs/source/functions.rst
+++ b/docs/source/functions.rst
@@ -1,0 +1,11 @@
+Column Functions
+================
+
+A counterpart of pyspark.sql.functions providing useful shortcuts, like a cleaner alternative to chaining together multiple when/otherwise statements.
+
+
+API documentation
+-----------------
+
+.. automodule:: sparkly.functions
+    :members:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -39,6 +39,7 @@ A brief tour on Sparkly features:
    spark.catalog_ext.get_table_properties('my_custom_table')
 
    # Easy integration testing with Fixtures and base test classes.
+   from pyspark.sql import types as T
    from sparkly.testing import SparklyTest
 
 
@@ -52,9 +53,9 @@ A brief tour on Sparkly features:
       def test_job_works_with_mysql(self):
          df = self.spark.read_ext.by_url('mysql://<my-testing-host>/<test-db>/<test-table>?user=<test-usre>&password=<test-password>')
          res_df = my_shiny_script(df)
-         self.assertDataFrameEqual(
-            res_df,
-            {'fieldA': 'DataA', 'fieldB': 'DataB', 'fieldC': 'DataC'},
+         self.assertRowsEqual(
+            res_df.collect(),
+            [T.Row(fieldA='DataA', fieldB='DataB', fieldC='DataC')],
          )
 
 .. toctree::

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -64,6 +64,7 @@ A brief tour on Sparkly features:
    reader_and_writer
    catalog
    testing
+   functions
    utils
    license
 

--- a/docs/source/reader_and_writer.rst
+++ b/docs/source/reader_and_writer.rst
@@ -172,6 +172,39 @@ Basically, it's just a high level api on top of the native
         'rewriteBatchedStatements': 'true',  # improves write throughput dramatically
     })
 
+.. _redis:
+
+Redis
+-----
+
+Sparkly provides a writer for Redis that is built on top of the official redis python library
+`redis-py <https://github.com/andymccurdy/redis-py>`_ .
+It is currently capable of exporting your DataFrame as a JSON blob per row or group of rows.
+
+.. note::
+    - To interact with Redis, ``sparkly`` needs the ``redis`` library. You can get it via:
+      ``pip install sparkly[redis]``
+
+.. code-block:: python
+
+    import json
+
+    from sparkly import SparklySession
+
+
+    spark = SparklySession()
+
+    # Write JSON.gz data indexed by col1.col2 that will expire in a day
+    df.write_ext.redis(
+        host='localhost',
+        port=6379,
+        key_by=['col1', 'col2'],
+        exclude_key_columns=True,
+        expire=24 * 60 * 60,
+        compression='gzip',
+    )
+
+
 .. _universal-reader-and-writer:
 
 Universal reader/writer

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,5 @@
 # limitations under the License.
 #
 
+pylru==1.0.9
 six==1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,17 @@
+#
+# Copyright 2017 Tubular Labs, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+six==1.10.0

--- a/requirements_extras.txt
+++ b/requirements_extras.txt
@@ -17,3 +17,5 @@
 cassandra-driver==3.7.1
 PyMySQL==0.7.9
 kafka-python==1.2.2
+redis==2.10.5
+ujson==1.35

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,7 @@ setup(
     install_requires=requirements,
     extras_require={
         'kafka': ['kafka-python>=1.2.2,<1.3'],
-        'test': ['cassandra-driver>=3.7,<3.8', 'PyMySQL>=0.7,<0.8', 'kafka-python>=1.2.2,<1.3'],
+        'redis': ['redis>=2.10,<3', 'ujson>=1.33,<2'],
+        'test': ['cassandra-driver>=3.7,<3.8', 'PyMySQL>=0.7,<0.8', 'kafka-python>=1.2.2,<1.3', 'redis>=2.10,<3', 'ujson>=1.33,<2'],
     },
 )

--- a/sparkly/__init__.py
+++ b/sparkly/__init__.py
@@ -19,4 +19,4 @@ from sparkly.session import SparklySession
 assert SparklySession
 
 
-__version__ = '2.2.1'
+__version__ = '2.3.0'

--- a/sparkly/functions.py
+++ b/sparkly/functions.py
@@ -1,0 +1,79 @@
+#
+# Copyright 2017 Tubular Labs, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from functools import reduce
+
+from pyspark.sql import Column
+from pyspark.sql import functions as F
+
+
+def switch_case(switch, case=None, default=None, **additional_cases):
+    """Switch/case style column generation.
+
+    Args:
+        switch (str, pyspark.sql.Column): column to "switch" on;
+            its values are going to be compared against defined cases.
+        case (dict): case statements. When a key matches the value of
+            the column in a specific row, the respective value will be
+            assigned to the new column for that row. This is useful when
+            your case condition constants are not strings.
+        default: default value to be used when the value of the switch
+            column doesn't match any keys.
+        additional_cases: additional "case" statements, kwargs style.
+            Same semantics with cases above. If both are provided,
+            cases takes precedence.
+
+    Returns:
+        pyspark.sql.Column
+
+    Example:
+        ``switch_case('state', CA='California', NY='New York', default='Other')``
+
+        is equivalent to
+
+        >>> F.when(
+        ... F.col('state') == 'CA', 'California'
+        ).when(
+        ... F.col('state') == 'NY', 'New York'
+        ).otherwise('Other')
+    """
+    if not isinstance(switch, Column):
+        switch = F.col(switch)
+
+    def _column_or_lit(x):
+        return F.lit(x) if not isinstance(x, Column) else x
+
+    def _execute_case(accumulator, case):
+        # transform the case to a pyspark.sql.functions.when statement,
+        # then chain it to existing when statements
+        condition_constant, assigned_value = case
+        when_args = (switch == F.lit(condition_constant), _column_or_lit(assigned_value))
+        return accumulator.when(*when_args)
+
+
+    cases = case or {}
+    for conflict in set(cases.keys()) & set(additional_cases.keys()):
+        del additional_cases[conflict]
+    cases = list(cases.items()) + list(additional_cases.items())
+
+    default = _column_or_lit(default)
+
+    if not cases:
+        return default
+
+    result = reduce(_execute_case, cases, F).otherwise(default)
+
+    return result

--- a/sparkly/utils.py
+++ b/sparkly/utils.py
@@ -15,6 +15,7 @@
 #
 
 import inspect
+from itertools import islice
 import os
 import re
 

--- a/sparkly/writer.py
+++ b/sparkly/writer.py
@@ -21,11 +21,29 @@ except ImportError:
 
 try:
     from kafka import KafkaProducer
-    KAFKA_WRITER_SUPPORT = True
 except ImportError:
     KAFKA_WRITER_SUPPORT = False
+else:
+    KAFKA_WRITER_SUPPORT = True
+
+try:
+    import redis
+except ImportError:
+    REDIS_WRITER_SUPPORT = False
+else:
+    import bz2
+    import gzip
+    import ujson
+    import uuid
+    import zlib
+    REDIS_WRITER_SUPPORT = True
+
+from functools import partial
+from itertools import islice
 
 from pyspark.sql import DataFrame
+from pyspark.sql import functions as F
+from pyspark.sql import types as T
 
 from sparkly.exceptions import WriteError
 
@@ -56,6 +74,7 @@ class SparklyWriter(object):
             - Elastic ``elastic://``
             - MySQL ``mysql://``
             - Parquet ``parquet://``
+            - Redis ``redis://`` or ``rediss://``
 
         Query string arguments are passed as parameters to the relevant writer.\n
         For instance, the next data export URL::
@@ -82,6 +101,7 @@ class SparklyWriter(object):
             parquet:///var/log/?partitionBy=date
             elastic://elastic.host/es_index/es_type
             mysql://mysql.host/database/table
+            redis://redis.host/db?keyBy=id
 
         Args:
             url (str): Destination URL.
@@ -255,6 +275,194 @@ class SparklyWriter(object):
 
         rdd.mapPartitions(write_partition_to_kafka).count()
 
+    def redis(self,
+              key_by,
+              key_prefix=None,
+              key_delimiter='.',
+              group_by_key=False,
+              exclude_key_columns=False,
+              exclude_null_fields=False,
+              expire=None,
+              compression=None,
+              max_pipeline_size=100,
+              parallelism=None,
+              mode='overwrite',
+              host=None,
+              port=6379,
+              db=0,
+              redis_client_init=None):
+        """Write a dataframe to Redis as JSON.
+
+        Args:
+            key_by (list[str]): Column names that form the redis key for
+                each row. The columns are concatenated in the order they
+                appear.
+            key_prefix (str|None): Common prefix to add to all keys from
+                this DataFrame. Useful to namespace DataFrame exports.
+            key_delimiter (str|.): Characters to delimit different columns
+                while forming the key.
+            group_by_key (bool|False): If set, group rows that share the
+                same redis key together in an array before exporting. By
+                default if multiple rows share the same redis key, one
+                will overwrite the other.
+            exclude_key_columns (bool|False): If set, exclude all columns
+                that comprise the key from the value being exported to
+                redis.
+            exclude_null_fields (bool|False): If set, exclude all fields
+                of a row that are null from the value being exported to
+                redis.
+            expire (int|None): Expire the keys after this number of seconds.
+            compression (str|None): Compress each Redis entry using this
+                protocol. Currently bzip2, gzip and zlib are supported.
+            max_pipeline_size (int|100): Number of writes to pipeline.
+            parallelism (int|None): The max number of parallel tasks that
+                could be executed during the write stage
+                (see :ref:`controlling-the-load`).
+            mode (str|overwrite):
+                - ``'append'``: Append to existing data on a key by key
+                  basis.
+                - ``'ignore'``: Silently ignore if data already exists.
+                - ``'overwrite'``: Flush all existing data before writing.
+            host (str|None): Redis host. Either this or redis_client_init
+                must be provided. See below.
+            port (int|6379): Port redis is listening to.
+            db (int|0): Redis db to write to.
+            redis_client_init (callable|None): Bypass internal redis
+                client initialization by passing a function that does it,
+                no arguments required. For example this could be
+                ``redis.StrictRedis.from_url`` with the appropriate url and
+                ``kwargs`` already set through ``functools.partial``.
+                This option overrides other conflicting arguments.
+
+        Raises:
+            NotImplementedError: if `redis-py` is not installed.
+            AssertionError: if nor host neither ``redis_client_init`` are
+                provided.
+            ValueError: if any of the ``expire``, ``compression``,
+                ``max_pipeline_size`` or ``mode`` options assume an
+                invalid value.
+        """
+        if not REDIS_WRITER_SUPPORT:
+            raise NotImplementedError(
+                'redis package is not available. Use pip install sparkly[redis] to fix it.'
+            )
+
+        assert host or redis_client_init, \
+            'redis: At least one of host or redis_client_init must be provided.'
+
+        if expire is not None and expire < 1:
+            raise ValueError('redis: expire must be positive')
+
+        if compression not in {None, 'bzip2', 'gzip', 'zlib'}:
+            raise ValueError(
+                'redis: bzip2, gzip and zlib are the only supported compression codecs.'
+            )
+
+        if max_pipeline_size < 1:
+            raise ValueError('redis: max pipeline size must be positive')
+
+        if mode not in {'append', 'ignore', 'overwrite'}:
+            raise ValueError(
+                'redis: only append (default), ignore and overwrite modes are supported.'
+            )
+
+        key_name = '_sparkly_redis_key_col_{}'.format(uuid.uuid4().hex)
+        value_name = '_sparkly_redis_value_col_{}'.format(uuid.uuid4().hex)
+
+        # Compute the key
+        df = self._df.withColumn(
+            key_name,
+            F.concat_ws(
+                key_delimiter,
+                *(
+                    ([F.lit(key_prefix).astype(T.StringType())] if key_prefix else []) +
+                    [F.col(col_name).astype(T.StringType()) for col_name in key_by]
+                )
+            )
+        )
+
+        if exclude_key_columns:
+            for col_name in key_by:
+                df = df.drop(col_name)
+
+        if group_by_key:
+            df = (
+                df
+                .withColumn(
+                    value_name,
+                    F.struct(*[col for col in df.columns if col != key_name])
+                )
+                .groupBy(key_name)
+                .agg(F.collect_list(value_name).alias(value_name))
+            )
+
+        # Repartition if needed to achieve specified parallelism
+        df = df.coalesce(parallelism or df.rdd.getNumPartitions())
+
+        def compress(data, protocol=None):
+            if protocol is None:
+                return data
+            elif protocol == 'bzip2':
+                return bz2.compress(data)
+            elif protocol == 'zlib':
+                return zlib.compress(data)
+            elif protocol == 'gzip':
+                try:
+                    return gzip.compress(data)
+                except AttributeError:  # py27
+                    compressor = zlib.compressobj(
+                        zlib.Z_DEFAULT_COMPRESSION,
+                        zlib.DEFLATED,
+                        zlib.MAX_WBITS | 16,
+                    )
+                    return compressor.compress(data) + compressor.flush()
+            else:
+                raise ValueError('unknown compression protocol {}'.format(protocol))
+
+        # Define the function that will write each partition to redis
+        def _write_redis(partition, redis, expire, compress, max_pipeline_size, mode):
+            pipeline = redis().pipeline(transaction=False)
+            add_to_pipeline = partial(pipeline.set, ex=expire, nx=(mode == 'ignore'))
+
+            partition = iter(partition)
+            while True:
+                rows = islice(partition, max_pipeline_size)
+                for row in rows:
+                    row = row.asDict(recursive=True)
+
+                    key = row.pop(key_name)
+                    if group_by_key:
+                        row = row[value_name]
+                    if exclude_null_fields:
+                        for null_field in list(f for f in row.keys() if row[f] is None):
+                            del row[null_field]
+                    data = bytes(ujson.dumps(row).encode('ascii'))
+                    if compress:
+                        data = compress(data)
+
+                    add_to_pipeline(key, data)
+
+                if not len(pipeline):
+                    break
+
+                pipeline.execute()
+
+        redis_client_init = redis_client_init or partial(redis.StrictRedis, host, port, db=db)
+
+        if mode == 'overwrite':
+            redis_client_init().flushdb()
+
+        df.foreachPartition(
+            partial(
+                _write_redis,
+                redis=redis_client_init,
+                expire=expire,
+                compress=partial(compress, protocol=compression),
+                max_pipeline_size=max_pipeline_size,
+                mode=mode,
+            )
+        )
+
     def _basic_write(self, writer_options, additional_options, parallelism, mode):
         if mode:
             writer_options['mode'] = mode
@@ -342,6 +550,69 @@ class SparklyWriter(object):
             format='parquet',
             **parsed_qs
         )
+
+    def _resolve_redis(self, parsed_url, parsed_qs):
+        # Extract all the custom options
+        try:
+            key_by = parsed_qs.pop('keyBy')
+        except KeyError:
+            raise AssertionError('redis: url must define keyBy columns to construct redis key')
+        key_by = key_by.split(',')
+
+        key_prefix = parsed_qs.pop('keyPrefix', None)
+        key_delimiter = parsed_qs.pop('keyDelimiter', '.')
+
+        def _parse_boolean(parameter, default='false'):
+            value = parsed_qs.pop(parameter, default).lower()
+            if value not in {'true', 'false'}:
+                raise ValueError(
+                    'redis: true and false (default) are the only supported {} values'
+                    .format(parameter)
+                )
+            return value == 'true'
+
+        group_by_key = _parse_boolean('groupByKey')
+        exclude_key_columns = _parse_boolean('excludeKeyColumns')
+        exclude_null_fields = _parse_boolean('excludeNullFields')
+
+        try:
+            expire = int(parsed_qs.pop('expire'))
+        except KeyError:
+            expire = None
+        except (TypeError, ValueError):
+            raise ValueError('redis: expire must be a base 10, positive integer')
+
+        compression = parsed_qs.pop('compression', None)
+
+        try:
+            max_pipeline_size = int(parsed_qs.pop('maxPipelineSize', 100))
+        except (TypeError, ValueError):
+            raise ValueError('redis: maxPipelineSize must be a base 10, positive integer')
+
+        parallelism = parsed_qs.pop('parallelism', None)
+        mode = parsed_qs.pop('mode', 'append')
+
+        # Reconstruct whatever remains of the original URL
+        url = parsed_url._replace(query='&'.join('='.join(o) for o in parsed_qs)).geturl()
+
+        return self.redis(
+            key_by=key_by,
+            key_prefix=key_prefix,
+            key_delimiter=key_delimiter,
+            group_by_key=group_by_key,
+            exclude_key_columns=exclude_key_columns,
+            exclude_null_fields=exclude_null_fields,
+            expire=expire,
+            compression=compression,
+            max_pipeline_size=max_pipeline_size,
+            parallelism=parallelism,
+            mode=mode,
+            # and then let redis-py decode it
+            redis_client_init=partial(redis.StrictRedis.from_url, url)
+        )
+
+    def _resolve_rediss(self, parsed_url, parsed_qs):
+        return self._resolve_redis(parsed_url, parsed_qs)
 
 
 def attach_writer_to_dataframe():

--- a/tests/integration/fake_modules/testing.py
+++ b/tests/integration/fake_modules/testing.py
@@ -1,0 +1,2 @@
+def is_fake():
+    return True

--- a/tests/integration/test_functions.py
+++ b/tests/integration/test_functions.py
@@ -1,0 +1,190 @@
+#
+# Copyright 2017 Tubular Labs, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pyspark.sql import functions as F
+from pyspark.sql import types as T
+
+from sparkly import functions as SF
+from sparkly.testing import SparklyGlobalSessionTest
+from tests.integration.base import SparklyTestSession
+
+
+class TestSwitchCase(SparklyGlobalSessionTest):
+    session = SparklyTestSession
+
+    def test_no_cases(self):
+        df = self.spark.createDataFrame(
+            data=[('one', ), ('two', ), ('three', ), ('hi', )],
+            schema=T.StructType([T.StructField('name', T.StringType())]),
+        )
+
+        df = df.withColumn('value', SF.switch_case('name'))
+
+        self.assertDataFrameEqual(
+            df,
+            [
+                {'name': 'one', 'value': None},
+                {'name': 'two', 'value': None},
+                {'name': 'three', 'value': None},
+                {'name': 'hi', 'value': None},
+            ],
+        )
+
+    def test_default_as_a_lit(self):
+        df = self.spark.createDataFrame(
+            data=[('one', ), ('two', ), ('three', ), ('hi', )],
+            schema=T.StructType([T.StructField('name', T.StringType())]),
+        )
+
+        df = df.withColumn('value', SF.switch_case('name', default=0))
+
+        self.assertDataFrameEqual(
+            df,
+            [
+                {'name': 'one', 'value': 0},
+                {'name': 'two', 'value': 0},
+                {'name': 'three', 'value': 0},
+                {'name': 'hi', 'value': 0},
+            ],
+        )
+
+    def test_default_as_a_column(self):
+        df = self.spark.createDataFrame(
+            data=[('one', ), ('two', ), ('three', ), ('hi', )],
+            schema=T.StructType([T.StructField('name', T.StringType())]),
+        )
+
+        df = df.withColumn('value', SF.switch_case('name', default=F.col('name')))
+
+        self.assertDataFrameEqual(
+            df,
+            [
+                {'name': 'one', 'value': 'one'},
+                {'name': 'two', 'value': 'two'},
+                {'name': 'three', 'value': 'three'},
+                {'name': 'hi', 'value': 'hi'},
+            ],
+        )
+
+    def test_switch_as_a_string_cases_as_kwargs(self):
+        df = self.spark.createDataFrame(
+            data=[('one', ), ('two', ), ('three', ), ('hi', )],
+            schema=T.StructType([T.StructField('name', T.StringType())]),
+        )
+
+        df = df.withColumn('value', SF.switch_case('name', one=1, two=2, three=3, default=0))
+
+        self.assertDataFrameEqual(
+            df,
+            [
+                {'name': 'one', 'value': 1},
+                {'name': 'two', 'value': 2},
+                {'name': 'three', 'value': 3},
+                {'name': 'hi', 'value': 0},
+            ],
+        )
+
+    def test_switch_as_a_column_cases_as_kwargs(self):
+        df = self.spark.createDataFrame(
+            data=[('one', ), ('two', ), ('three', ), ('hi', )],
+            schema=T.StructType([T.StructField('name', T.StringType())]),
+        )
+
+        df = df.withColumn(
+            'value',
+            SF.switch_case(F.col('name'), one=1, two=2, three=3, default=0),
+        )
+
+        self.assertDataFrameEqual(
+            df,
+            [
+                {'name': 'one', 'value': 1},
+                {'name': 'two', 'value': 2},
+                {'name': 'three', 'value': 3},
+                {'name': 'hi', 'value': 0},
+            ],
+        )
+
+    def test_dict_cases_override_kwarg_cases(self):
+        df = self.spark.createDataFrame(
+            data=[('one', ), ('two', ), ('three', ), ('hi', )],
+            schema=T.StructType([T.StructField('name', T.StringType())]),
+        )
+
+        df = df.withColumn(
+            'value',
+            SF.switch_case('name', {'one': 11, 'three': 33}, one=1, two=2, three=3, default=0),
+        )
+
+        self.assertDataFrameEqual(
+            df,
+            [
+                {'name': 'one', 'value': 11},
+                {'name': 'two', 'value': 2},
+                {'name': 'three', 'value': 33},
+                {'name': 'hi', 'value': 0},
+            ],
+        )
+
+    def test_cases_condition_constant_as_an_arbitrary_value(self):
+        df = self.spark.createDataFrame(
+            data=[(1, ), (2, ), (3, ), (0, )],
+            schema=T.StructType([T.StructField('value', T.IntegerType())]),
+        )
+
+        df = df.withColumn(
+            'name',
+            SF.switch_case('value', {1: 'one', 2: 'two', 3: 'three'}, default='hi'),
+        )
+
+        self.assertDataFrameEqual(
+            df,
+            [
+                {'name': 'one', 'value': 1},
+                {'name': 'two', 'value': 2},
+                {'name': 'three', 'value': 3},
+                {'name': 'hi', 'value': 0},
+            ],
+        )
+
+    def test_cases_values_as_a_column(self):
+        df = self.spark.createDataFrame(
+            data=[(1, ), (2, ), (3, ), (0, )],
+            schema=T.StructType([T.StructField('value', T.IntegerType())]),
+        )
+
+        df = df.withColumn(
+            'value_2',
+            SF.switch_case(
+                'value',
+                {
+                    1: 11 * F.col('value'),
+                    2: F.col('value') * F.col('value'),
+                    'hi': 5,
+                },
+                default=F.col('value'),
+            ),
+        )
+
+        self.assertDataFrameEqual(
+            df,
+            [
+                {'value': 1, 'value_2': 11},
+                {'value': 2, 'value_2': 4},
+                {'value': 3, 'value_2': 3},
+                {'value': 0, 'value_2': 0},
+            ],
+        )

--- a/tests/integration/test_testing.py
+++ b/tests/integration/test_testing.py
@@ -16,6 +16,7 @@
 import json
 import uuid
 import pickle
+import unittest
 
 from sparkly.testing import (
     CassandraFixture,
@@ -59,6 +60,20 @@ class TestAssertions(SparklyGlobalSessionTest):
                  ],
                 ordered=True,
             )
+
+
+class TestSparklyGlobalSessionTest(unittest.TestCase):
+
+    def test_imports_test_target(self):
+
+        class MyGlobalTest(SparklyGlobalSessionTest):
+            session = SparklyTestSession
+            test_target = 'tests.integration.fake_modules.testing.is_fake'
+
+
+        MyGlobalTest.setUpClass()
+
+        self.assertTrue(is_fake)
 
 
 class TestCassandraFixtures(SparklyGlobalSessionTest):

--- a/tests/unit/test_testing.py
+++ b/tests/unit/test_testing.py
@@ -1,0 +1,368 @@
+#
+# Copyright 2017 Tubular Labs, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import unittest
+
+from pyspark.sql import types as T
+
+from sparkly.testing import SparklyTest as SparklyTestSuite
+
+
+class SparklyTest(SparklyTestSuite):
+    session = None
+
+    @classmethod
+    def setUpClass(cls):
+        pass
+
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
+    # py27 complains that it doesn't find it...
+    def runTest(self):
+        pass
+
+
+class TestAssertRowsEqual(unittest.TestCase):
+
+    # shallow comparisons
+    def test_dict(self):
+        first = dict([('one', 1), ('two', 2), ('three', 3), ('four', 4)])
+        second = dict([('three', 3), ('two', 2), ('four', 4), ('one', 1)])
+
+        SparklyTest().assertRowsEqual(first, second, ignore_order=True)
+        SparklyTest().assertRowsEqual(first, second, ignore_order=False)
+
+        # change entry ('four', 4)
+        second = dict([('three', 3), ('two', 2), ('four', 44), ('one', 1)])
+
+        with self.assertRaises(AssertionError):
+            SparklyTest().assertRowsEqual(first, second, ignore_order=True)
+
+    def test_list(self):
+        first = ['one', 'two', 'three', 'four']
+        second = ['three', 'two', 'four', 'one']
+
+        SparklyTest().assertRowsEqual(first, second, ignore_order=True)
+
+        with self.assertRaises(AssertionError):
+            SparklyTest().assertRowsEqual(first, second, ignore_order=False)
+
+        # change entry 'four'
+        second = ['three', 'two', 'fourrrr', 'one']
+
+        with self.assertRaises(AssertionError):
+            SparklyTest().assertRowsEqual(first, second, ignore_order=True)
+
+    def test_row(self):
+        first = T.Row(one=1, two=2, three=3, four=4)
+        second = T.Row(three=3, two=2, four=4, one=1)
+
+        # Spark currently sorts the fields of each row internally
+        # so these will match...
+        SparklyTest().assertRowsEqual(first, second)
+        self.assertEqual(first, second)
+
+        # but since Rows extend tuples, only the values are checked as
+        # long as the fields define the same alpha order
+        first = T.Row(one=1, two=2, three=3, four=4)
+        second = T.Row(th=3, tw=2, f=4, o=1)
+
+        # We fix this in our version by default
+        with self.assertRaises(AssertionError):
+            SparklyTest().assertRowsEqual(first, second)
+        self.assertEqual(first, second)
+
+    def test_datatype(self):
+        first = T.StructType([
+            T.StructField('f1', T.BooleanType()),
+            T.StructField('f2', T.ByteType()),
+            T.StructField('f3', T.IntegerType()),
+            T.StructField('f4', T.LongType()),
+        ])
+        second = T.StructType([
+            T.StructField('f3', T.IntegerType()),
+            T.StructField('f2', T.ByteType()),
+            T.StructField('f4', T.LongType()),
+            T.StructField('f1', T.BooleanType()),
+        ])
+
+        SparklyTest().assertRowsEqual(first, second, ignore_order=True)
+        with self.assertRaises(AssertionError):
+            self.assertEqual(first, second)
+
+        # change entry (f4, T.LongType)
+        second = T.StructType([
+            T.StructField('f3', T.IntegerType()),
+            T.StructField('f2', T.ByteType()),
+            T.StructField('f4', T.StringType()),
+            T.StructField('f1', T.BooleanType()),
+        ])
+
+        with self.assertRaises(AssertionError):
+            SparklyTest().assertRowsEqual(first, second, ignore_order=True)
+
+    def test_float(self):
+        with self.assertRaises(AssertionError):
+            SparklyTest().assertRowsEqual(0.51, 0.5)
+
+        # Absolute tolerance
+        with self.assertRaises(AssertionError):
+            SparklyTest().assertRowsEqual(0.51, 0.5, atol=0.009)
+        SparklyTest().assertRowsEqual(0.51, 0.5, atol=0.01)
+
+        # Relative tolerance
+        with self.assertRaises(AssertionError):
+            SparklyTest().assertRowsEqual(0.51, 0.5, rtol=0.019)
+        SparklyTest().assertRowsEqual(0.51, 0.5, rtol=0.021)
+
+        # Relative + absolute tolerance
+        with self.assertRaises(AssertionError):
+            SparklyTest().assertRowsEqual(0.51, 0.5, rtol=0.009, atol=0.004)
+        SparklyTest().assertRowsEqual(0.51, 0.5, rtol=0.01, atol=0.006)
+
+        # Equal Nans
+        with self.assertRaises(AssertionError):
+            SparklyTest().assertRowsEqual(float('NaN'), float('NaN'), equal_nan=False)
+        SparklyTest().assertRowsEqual(float('NaN'), float('NaN'))
+
+    # nested
+    def test_row_with_rows_arrays_and_maps(self):
+        first = [
+            T.Row(
+                one=1,
+                two=T.Row(
+                    array=[
+                        T.Row(income=10, month='2017-01'),
+                        T.Row(income=9, month='2017-02'),
+                        T.Row(income=8, month='2017-03'),
+                    ],
+                    map={
+                        '2017-01': [1, 11, 111],
+                        '2017-02': [2, 22, 222],
+                        '2017-03': [3, 33, 333],
+                    },
+                    row=T.Row(my_id=2, my_desired_id=4)
+                ),
+                three=None,
+                four=None,
+            ),
+            T.Row(
+                one=None,
+                two=None,
+                three=[{'2017-01': 201701}, {'2017-02': 201702}, {'2017-03': 201703}],
+                four={
+                    '2017-01': T.Row(income=1, job='engineer'),
+                    '2017-02': T.Row(income=2, job='cto'),
+                    '2017-03': T.Row(income=3, job='ceo'),
+                },
+            ),
+        ]
+        second = [
+            T.Row(
+                three=[{'2017-02': 201702}, {'2017-01': 201701}, {'2017-03': 201703}],
+                two=None,
+                four={
+                    '2017-01': T.Row(job='engineer', income=1),
+                    '2017-02': T.Row(income=2, job='cto'),
+                    '2017-03': T.Row(job='ceo', income=3),
+                },
+                one=None,
+            ),
+            T.Row(
+                two=T.Row(
+                    map={
+                        '2017-01': [11, 1, 111],
+                        '2017-02': [22, 222, 2],
+                        '2017-03': [3, 33, 333],
+                    },
+                    array=[
+                        T.Row(month='2017-03', income=8),
+                        T.Row(month='2017-02', income=9),
+                        T.Row(month='2017-01', income=10),
+                    ],
+                    row=T.Row(my_desired_id=4, my_id=2)
+                ),
+                four=None,
+                three=None,
+                one=1,
+            ),
+        ]
+
+        SparklyTest().assertRowsEqual(first, second, ignore_order=True)
+
+        with self.assertRaises(AssertionError):
+            SparklyTest().assertRowsEqual(first, second, ignore_order=False)
+        with self.assertRaises(AssertionError):
+            self.assertEqual(first, second)
+
+        # let's mess that equality up
+        second[1]['two']['map']['2017-01'] = None
+        with self.assertRaises(AssertionError):
+            SparklyTest().assertRowsEqual(first, second, ignore_order=True)
+
+    def test_datatype_with_structs_arrays_and_maps(self):
+        first = T.StructType([
+            T.StructField('f1', T.BooleanType()),
+            T.StructField(
+                'f2',
+                T.StructType([
+                    T.StructField(
+                        's1',
+                        T.ArrayType(T.StructType([
+                            T.StructField('ss1', T.BooleanType()),
+                            T.StructField('ss2', T.ByteType())
+                        ])),
+                    ),
+                ]),
+            ),
+            T.StructField('f3', T.ArrayType(T.MapType(T.StringType(), T.IntegerType()))),
+            T.StructField(
+                'f4',
+                T.MapType(
+                    T.StringType(),
+                    T.StructType([
+                        T.StructField('ss1', T.IntegerType()),
+                        T.StructField('ss2', T.LongType()),
+                    ])),
+            ),
+        ])
+        second = T.StructType([
+            T.StructField('f3', T.ArrayType(T.MapType(T.StringType(), T.IntegerType()))),
+            T.StructField(
+                'f2',
+                T.StructType([
+                    T.StructField(
+                        's1',
+                        T.ArrayType(T.StructType([
+                            T.StructField('ss2', T.ByteType()),
+                            T.StructField('ss1', T.BooleanType()),
+                        ])),
+                    ),
+                ]),
+            ),
+            T.StructField(
+                'f4',
+                T.MapType(
+                    T.StringType(),
+                    T.StructType([
+                        T.StructField('ss2', T.LongType()),
+                        T.StructField('ss1', T.IntegerType()),
+                    ])),
+            ),
+            T.StructField('f1', T.BooleanType()),
+        ])
+
+        SparklyTest().assertRowsEqual(first, second, ignore_order=True)
+        with self.assertRaises(AssertionError):
+            self.assertEqual(first, second)
+
+        # change entry (f4.ss1, T.LongType)
+        second = T.StructType([
+            T.StructField('f3', T.ArrayType(T.MapType(T.StringType(), T.IntegerType()))),
+            T.StructField(
+                'f2',
+                T.StructType([
+                    T.StructField(
+                        's1',
+                        T.ArrayType(T.StructType([
+                            T.StructField('ss2', T.ByteType()),
+                            T.StructField('ss1', T.BooleanType()),
+                        ])),
+                    ),
+                ]),
+            ),
+            T.StructField(
+                'f4',
+                T.MapType(
+                    T.StringType(),
+                    T.StructType([
+                        T.StructField('ss2', T.LongType()),
+                        T.StructField('ss1', T.LongType()),
+                    ])),
+            ),
+            T.StructField('f1', T.BooleanType()),
+        ])
+
+        with self.assertRaises(AssertionError):
+            SparklyTest().assertRowsEqual(first, second, ignore_order=True)
+
+    def test_float_nested_in_tuples(self):
+        first = {
+            '2017-01': [2.6, 2.7, 2.8],
+            '2017-02': [12.6, 12.7, 12.8],
+        }
+        second = {
+            '2017-01': [2.4, 2.5, 2.6],
+            '2017-02': [11.6, 11.7, 11.8],
+        }
+
+        SparklyTest().assertRowsEqual(first, second, rtol=0.1, ignore_order=True)
+        with self.assertRaises(AssertionError):
+            SparklyTest().assertRowsEqual(first, second, ignore_order=True)
+
+    # various
+    def test_asserters_do_not_persist_between_calls(self):
+        testing_instance = SparklyTest()
+
+        testing_instance.assertRowsEqual(0.5, 0.51, rtol=0.1)
+
+        with self.assertRaises(AssertionError):
+            testing_instance.assertEqual(0.5, 0.51)
+
+    def test_ignore_order_depth(self):
+        first = [
+            [{'one': [1, 11]}, {'eleven': [11, 111]}],
+            [{'two': [2, 22]}, {'twenty two': [22, 222]}],
+            [{'three': [3, 33]}, {'thirty three': [33, 333]}],
+        ]
+
+        # depth 1 permutation
+        second = [
+            [{'two': [2, 22]}, {'twenty two': [22, 222]}],
+            [{'one': [1, 11]}, {'eleven': [11, 111]}],
+            [{'three': [3, 33]}, {'thirty three': [33, 333]}],
+        ]
+
+        SparklyTest().assertRowsEqual(first, second, ignore_order=True, ignore_order_depth=1)
+        with self.assertRaises(AssertionError):
+            SparklyTest().assertRowsEqual(first, second, ignore_order=False)
+
+        # depth 2 permutation ('twenty two' <-> 'two')
+        second = [
+            [{'twenty two': [22, 222]}, {'two': [2, 22]}],
+            [{'one': [1, 11]}, {'eleven': [11, 111]}],
+            [{'three': [3, 33]}, {'thirty three': [33, 333]}],
+        ]
+
+        SparklyTest().assertRowsEqual(first, second, ignore_order=True, ignore_order_depth=2)
+        with self.assertRaises(AssertionError):
+            SparklyTest().assertRowsEqual(first, second, ignore_order=True, ignore_order_depth=1)
+        with self.assertRaises(AssertionError):
+            SparklyTest().assertRowsEqual(first, second, ignore_order=False)
+
+        # as deep as we can get (22 <-> 222, 11 <-> 111)
+        second = [
+            [{'twenty two': [222, 22]}, {'two': [2, 22]}],
+            [{'one': [1, 11]}, {'eleven': [111, 11]}],
+            [{'three': [3, 33]}, {'thirty three': [33, 333]}],
+        ]
+        SparklyTest().assertRowsEqual(first, second, ignore_order=True, ignore_order_depth=3)
+        SparklyTest().assertRowsEqual(first, second, ignore_order=True, ignore_order_depth=0)
+        SparklyTest().assertRowsEqual(first, second, ignore_order=True, ignore_order_depth=-1)
+        SparklyTest().assertRowsEqual(first, second, ignore_order=True)
+        with self.assertRaises(AssertionError):
+            SparklyTest().assertRowsEqual(first, second, ignore_order=True, ignore_order_depth=2)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -15,8 +15,16 @@
 #
 
 from unittest import TestCase
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
-from sparkly.utils import parse_schema
+from pyspark import StorageLevel
+from pyspark.sql import DataFrame
+from pyspark.sql import types as T
+
+from sparkly.utils import lru_cache, parse_schema
 
 
 class TestParseSchema(TestCase):
@@ -44,3 +52,45 @@ class TestParseSchema(TestCase):
 
     def assert_parsed_properly(self, schema):
         self.assertEqual(parse_schema(schema).simpleString(), schema)
+
+
+class TestLruCache(TestCase):
+    def test_caching(self):
+        df = mock.MagicMock(spec=DataFrame)
+
+        called = [0]
+
+        @lru_cache(storage_level=StorageLevel.DISK_ONLY)
+        def func(*args, **kwargs):
+            called[0] += 1
+            return df
+
+        func()
+        df.persist.assert_called_once_with(StorageLevel.DISK_ONLY)
+        self.assertEqual(df.unpersist.mock_calls, [])
+        self.assertEqual(called[0], 1)
+
+        cached_df = func()
+        self.assertEqual(cached_df, df)
+        self.assertEqual(called[0], 1)
+
+    def test_eviction(self):
+        first_df = mock.MagicMock(spec=DataFrame)
+        second_df = mock.MagicMock(spec=DataFrame)
+
+        @lru_cache(maxsize=1, storage_level=StorageLevel.DISK_ONLY)
+        def func(uid):
+            if uid == 'first':
+                return first_df
+            else:
+                return second_df
+
+        func('first')
+        first_df.persist.assert_called_once_with(StorageLevel.DISK_ONLY)
+        self.assertEqual(first_df.unpersist.mock_calls, [])
+
+        func('second')
+        first_df.persist.assert_called_once_with(StorageLevel.DISK_ONLY)
+        first_df.unpersist.assert_called_once_with()
+        second_df.persist.assert_called_once_with(StorageLevel.DISK_ONLY)
+        self.assertEqual(second_df.unpersist.mock_calls, [])


### PR DESCRIPTION
This PR provides a variety of useful features (one per commit). Briefly:

**Catalog**
Overwrite location of external table in catalog.

**Functions (or, shortcuts)**
* "Switch/case" column generation. Can replace chained `when`s on a column value.
* Join multiple DataFrames at once and coalesce ambiguous columns across them.

**Testing**
Extend `assertEqual` to to work better with comparisons involving rows, datatypes, dictionaries, lists and floats by:
- ignoring the order of lists and datatypes recursively (useful to compare DataFrames that might contain nested arrays of structs of ... (etc) where order does not matter),
- comparing floats within a given tolerance,
- assuming NaNs are equal,
- ignoring the nullability requirements of datatypes (since Spark can be inaccurate when inferring it),
- providing better diffs for rows and datatypes.

**Writing**
Support `redis://` and `rediss://` URLs.

**Other**
* Check whether a complex `dataType` defines a minimum set of required fields. Useful for schema assertions.
* LRU DataFrame caching. Provide a unified decorator that persists DataFrames (when it encounters them) according to user settings in addition to caching the actual python object. Useful in case a user defined transformation is called in multiple places in a project and the user wants to control whether the data is being persisted to memory / disk without having to change any code.