### PR TITLE
FIX sparkly.catalog_ext to work with different dbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.1.1
+* Fix: remove backtick quoting from catalog utils to ease work with different databases.
+
 ## 2.1.0
 * Add ability to specify custom maven repositories.
 

--- a/docs/source/catalog.rst
+++ b/docs/source/catalog.rst
@@ -65,6 +65,35 @@ We implemented a more convenient interface to make your code cleaner.
 In case if you need other types, consider using a serialisation format, e.g. JSON.
 
 
+Using non-default database
+--------------------------
+
+**Why** to split your warehouse into logical groups (for example by system components).
+In all catalog_ext.* methods you can specify full table names <db-name>.<table-name> and
+it should operate properly
+
+.. code-block:: python
+
+    from time import time
+    from sparkly import SparklySession
+
+    spark = SparklySession()
+
+    if spark.catalog_ext.has_database('my_database'):
+        self.catalog_ext.rename_table(
+            'my_database.my_badly_named_table',
+            'new_shiny_name',
+        )
+        self.catalog_ext.set_table_property(
+            'my_database.new_shiny_name',
+            'last_update_at',
+            time(),
+        )
+
+*Note* be careful using 'USE' statements like: spark.sql('USE my_database'),
+it's stateful and may lead to weird errors, if code assumes correct current database.
+
+
 API documentation
 -----------------
 

--- a/sparkly/__init__.py
+++ b/sparkly/__init__.py
@@ -19,4 +19,4 @@ from sparkly.session import SparklySession
 assert SparklySession
 
 
-__version__ = '2.1.0'
+__version__ = '2.1.1'

--- a/sparkly/catalog.py
+++ b/sparkly/catalog.py
@@ -77,12 +77,14 @@ class SparklyCatalog(object):
         Returns:
             bool
         """
-        try:
-            self._spark.catalog.listTables(db_name)
-        except Exception:
-            return False
-        else:
+        if not db_name:
             return True
+
+        for db in self._spark.catalog.listDatabases():
+            if db_name == db.name:
+                return True
+
+        return False
 
     def rename_table(self, old_table_name, new_table_name):
         """Rename table in the metastore.


### PR DESCRIPTION
## 2.1.1
* Fix: remove backtick quoting from catalog utils to ease work with different databases.