### PR TITLE
Use str for SparklyTest options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.2.1
+* `spark.sql.shuffle.partitions` in `SparklyTest` should be set to string,
+because `int` value breaks integration testing in Spark 2.0.2. 
+
 # 2.2.0
 * Add instant iterative development mode. `sparkly-testing --help` for more details.
 * Use in-memory db for Hive Metastore in `SparklyTest` (faster tests).

--- a/sparkly/__init__.py
+++ b/sparkly/__init__.py
@@ -19,4 +19,4 @@ from sparkly.session import SparklySession
 assert SparklySession
 
 
-__version__ = '2.2.0'
+__version__ = '2.2.1'

--- a/sparkly/testing.py
+++ b/sparkly/testing.py
@@ -91,7 +91,7 @@ class SparklyTest(TestCase):
             'spark.sql.warehouse.dir': tempfile.mkdtemp(suffix='sparkly'),
 
             # Reduce number of shuffle partitions (faster tests).
-            'spark.sql.shuffle.partitions': 4,
+            'spark.sql.shuffle.partitions': '4',
         })
 
     @classmethod


### PR DESCRIPTION
* `spark.sql.shuffle.partitions` in `SparklyTest` should be set to string,
because `int` value breaks integration testing in Spark 2.0.2.