### PR TITLE
IMP get or create sparkly session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.4.0
+* Access or initialize SparklySession through get_or_create classmethod
+
 ## 2.3.0
 * Overwrite existing tables in the metastore
 * Add functions module and provide switch_case column generation and multijoin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
       test: ps ax | grep elastic
 
   mysql.docker:
-    image: mysql
+    image: mysql:5.7
     environment:
       MYSQL_DATABASE: sparkly_test
       MYSQL_USER: root

--- a/sparkly/__init__.py
+++ b/sparkly/__init__.py
@@ -19,4 +19,4 @@ from sparkly.session import SparklySession
 assert SparklySession
 
 
-__version__ = '2.3.0'
+__version__ = '2.4.0'

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -137,3 +137,34 @@ class TestSparklySession(unittest.TestCase):
             }
 
         self.assertRaises(NotImplementedError, _Session)
+
+    @mock.patch('sparkly.session.SparkSession')
+    def test_get_or_create_and_stop(self, spark_session_mock):
+        # Not a great practice to test two functions in one unit test,
+        # but get_or_create and stop are kind of intertwined with each other
+
+        class _Session(SparklySession):
+            pass
+
+        # check stopping a running session
+        original_session = _Session()
+        _Session.stop()
+        spark_session_mock.stop.assert_called_once_with(original_session)
+
+        # check that stopping when there's no session has no impact
+        _Session.stop()
+        spark_session_mock.stop.assert_called_once_with(original_session)
+
+        # check creating a new session thru get_or_create
+        retrieved_session = _Session.get_or_create()
+        self.assertNotEqual(id(retrieved_session), id(original_session))
+
+        # check retrieving a session thru get_or_create
+        original_session = _Session()
+        retrieved_session = _Session.get_or_create()
+        self.assertEqual(id(retrieved_session), id(original_session))
+
+        # check retrieving a session thru SparklySession.get_or_create
+        original_session = _Session()
+        retrieved_session = SparklySession.get_or_create()
+        self.assertEqual(id(retrieved_session), id(original_session))


### PR DESCRIPTION
Provide class method to access the running instance of a sparkly session if one exists, otherwise create one.

**Why:**

A lot of times you might need access to the sparkly session at a low-level, deeply nested function in your code. A first approach is to declare a global sparkly session instance that you access explicitly, but this usually makes testing painful because of unexpected importing side effects. A second approach is to pass the session instance explicitly as a function argument, but this makes the code ugly since you then need to propagate that argument all the way up to every caller of that function.

Other times you might want to be able to glue together and run one after the other different code segments, where each segment initializes its own sparkly session, despite the sessions being identical. This situation could occur when you are doing investigative work in a notebook.

The solution proposed here solves both of these problems while keeping code clutter at a minimum.