### PR TITLE
IMP custom operand evaluation in switch_case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 2.4.0
 * Access or initialize SparklySession through get_or_create classmethod
+* Ammend `sparkly.functions.switch_case` to accept a user defined function for
+  deciding whether the switch column matches a specific case
 
 ## 2.3.0
 * Overwrite existing tables in the metastore

--- a/sparkly/functions.py
+++ b/sparkly/functions.py
@@ -16,6 +16,7 @@
 
 from collections import defaultdict
 from functools import reduce
+import operator
 
 from pyspark.sql import Column
 from pyspark.sql import functions as F
@@ -78,7 +79,7 @@ def multijoin(dfs, on=None, how=None, coalesce=None):
     return joined_df
 
 
-def switch_case(switch, case=None, default=None, operand=Column.__eq__, **additional_cases):
+def switch_case(switch, case=None, default=None, operand=operator.eq, **additional_cases):
     """Switch/case style column generation.
 
     Args:
@@ -91,7 +92,7 @@ def switch_case(switch, case=None, default=None, operand=Column.__eq__, **additi
         default: default value to be used when the value of the switch
             column doesn't match any keys.
         operand: function to compare the value of the switch column to the
-            value of each case. Default is Column.__eq__. If user-provided,
+            value of each case. Default is Column's eq. If user-provided,
             first argument will always be the switch Column; it's the
             user's responsibility to transform the case value to a column
             if they need to.

--- a/tests/integration/test_functions.py
+++ b/tests/integration/test_functions.py
@@ -15,8 +15,8 @@
 #
 
 from collections import OrderedDict
+import operator
 
-from pyspark.sql import Column
 from pyspark.sql import functions as F
 from pyspark.sql import types as T
 from pyspark.sql import utils as U
@@ -346,7 +346,7 @@ class TestSwitchCase(SparklyGlobalSessionTest):
                     (3, 'good'),
                     (4, 'best'),
                 ]),
-                operand=Column.__lt__,
+                operand=operator.lt,
             ),
         )
 


### PR DESCRIPTION
Enable the user to define the function that switch_case uses internally
to decide which case the switch statement matches. This allows the function
to be used in a variety of usecases, for example when bucketizing an
integer value.