### PR TITLE
FIX respect PYSPARK_SUBMIT_ARGS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## 2.4.0
+* Respect PYSPARK_SUBMIT_ARGS if it is already set by appending SparklySession related options at the end instead of overwriting.
+* Fix additional_options to always override SparklySession.options when a session is initialized
 * Fix ujson dependency on environments where redis-py is already installed
 * Access or initialize SparklySession through get_or_create classmethod
 * Ammend `sparkly.functions.switch_case` to accept a user defined function for

--- a/docs/source/session.rst
+++ b/docs/source/session.rst
@@ -123,6 +123,28 @@ Tuning options
     spark = MySession({'spark.sql.shuffle.partitions': 10})
 
 
+Tuning options through shell environment
+----------------------------------------
+
+**Why**: You want to customize your spark session in a way that depends on the
+hardware specifications of your worker (or driver) machine(s), so you'd rather
+define them close to where the actual machine specs are requested / defined.
+Or you just want to test some new configuration without having to change your
+code. In both cases, you can do so by using the environmental variable
+``PYSPARK_SUBMIT_ARGS``. Note that any options defined this way will override
+any conflicting options from your Python code.
+
+**For example**:
+
+    - ``spark.executor.cores`` to tune the cores used by each executor;
+    - ``spark.executor.memory`` to tune the memory available to each executor.
+
+.. code-block:: sh
+
+    PYSPARK_SUBMIT_ARGS='--conf "spark.executor.cores=32" --conf "spark.executor.memory=160g"' \
+        ./my_spark_app.py
+
+
 Using UDFs
 ----------
 


### PR DESCRIPTION
SparklySession used to overwrite PYSPARK_SUBMIT_ARGS; instead we now append to it.

**Why:** 

You want to customize your spark session in a way that depends on the hardware specifications of your worker (or driver) machine(s), so you'd rather define such options close to where the actual machine specs are requested / defined. Or you just want to test some new configuration without having to change your code. In both cases, you can do so by using the environmental variable `PYSPARK_SUBMIT_ARGS` appropriately.

**Also:**

This commit also includes the following fix: the order in which options were processed in the case of `SparklySession.options` and `additional_options` specifying conflicting values was arbitrary, as the option whose value was alphabetically greater was selected. We now force the following precedence order:

```
PYSPARK_SUBMIT_ARGS (--conf) > additional_options > SparklySession.options
```