### PR TITLE
FIX ujson requirement when redis is pre-installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 2.4.0
+* Fix ujson dependency on environments where redis-py is already installed
 * Access or initialize SparklySession through get_or_create classmethod
 * Ammend `sparkly.functions.switch_case` to accept a user defined function for
   deciding whether the switch column matches a specific case

--- a/sparkly/writer.py
+++ b/sparkly/writer.py
@@ -28,12 +28,12 @@ else:
 
 try:
     import redis
+    import ujson
 except ImportError:
     REDIS_WRITER_SUPPORT = False
 else:
     import bz2
     import gzip
-    import ujson
     import uuid
     import zlib
     REDIS_WRITER_SUPPORT = True


### PR DESCRIPTION
In environments where redis-py was already installed but the user
installed sparkly without redis support, the writer would be confused
and assume that ujson should be importable