### PR TITLE
Extend SparklyCatalog to work with database properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.8.0
+* Extend `SparklyCatalog` to work with database properties:
+- `spark.catalog_ext.set_database_property`
+- `spark.catalog_ext.get_database_property`
+- `spark.catalog_ext.get_database_properties`
+
 ## 2.7.1
 * Allow newer versions of `six` package (avoid depednecy hell)
 

--- a/sparkly/__init__.py
+++ b/sparkly/__init__.py
@@ -19,4 +19,4 @@ from sparkly.session import SparklySession
 assert SparklySession
 
 
-__version__ = '2.7.1'
+__version__ = '2.8.0'


### PR DESCRIPTION
New methods:
- `spark.catalog_ext.set_database_property`
- `spark.catalog_ext.get_database_property`
- `spark.catalog_ext.get_database_properties`