### PR TITLE
IMP support elasticsearch 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.8.1
+* Fix support for using multiple sparkly sessions during tests
+* SparklySession does not persist modifications to os.environ
+
 ## 2.8.0
 * Extend `SparklyCatalog` to work with database properties:
 - `spark.catalog_ext.set_database_property`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.8.1
 * Fix support for using multiple sparkly sessions during tests
 * SparklySession does not persist modifications to os.environ
+* Support ElasticSearch 7 by making type optional.
 
 ## 2.8.0
 * Extend `SparklyCatalog` to work with database properties:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,9 @@ services:
     depends_on:
       cassandra.docker:
         condition: service_healthy
-      elastic.docker:
+      elastic6.docker:
+        condition: service_healthy
+      elastic7.docker:
         condition: service_healthy
       kafka.docker:
         condition: service_healthy
@@ -37,7 +39,9 @@ services:
     depends_on:
       cassandra.docker:
         condition: service_healthy
-      elastic.docker:
+      elastic6.docker:
+        condition: service_healthy
+      elastic7.docker:
         condition: service_healthy
       kafka.docker:
         condition: service_healthy
@@ -56,10 +60,29 @@ services:
     healthcheck:
       test: ps ax | grep cassandra
 
-  elastic.docker:
+  elastic6.docker:
     image: docker.elastic.co/elasticsearch/elasticsearch:6.5.4
+    environment:
+      - xpack.security.enabled=false
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - discovery.type=single-node
     healthcheck:
-      test: ps ax | grep elastic
+      test: "curl -f http://localhost:9200/_cat/health | grep green"
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  elastic7.docker:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.3.0
+    environment:
+      - xpack.security.enabled=false
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - discovery.type=single-node
+    healthcheck:
+      test: "curl -f http://localhost:9200/_cat/health | grep green"
+      interval: 5s
+      timeout: 5s
+      retries: 20
 
   mysql.docker:
     image: mysql:5.7

--- a/sparkly/__init__.py
+++ b/sparkly/__init__.py
@@ -19,4 +19,4 @@ from sparkly.session import SparklySession
 assert SparklySession
 
 
-__version__ = '2.8.0'
+__version__ = '2.8.1'

--- a/sparkly/session.py
+++ b/sparkly/session.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+from copy import deepcopy
 import os
 import signal
 import sys
@@ -77,8 +78,10 @@ class SparklySession(SparkSession):
     repositories = []
 
     _instantiated_session = None
+    _original_environment = None
 
     def __init__(self, additional_options=None):
+        SparklySession._original_environment = deepcopy(os.environ)
         os.environ['PYSPARK_PYTHON'] = sys.executable
 
         submit_args = [
@@ -138,6 +141,8 @@ class SparklySession(SparkSession):
         if SparklySession._instantiated_session is not None:
             SparkSession.stop(SparklySession._instantiated_session)
             SparklySession._instantiated_session = None
+            os.environ = SparklySession._original_environment
+            SparklySession._original_environment = None
 
     @property
     def builder(self):

--- a/sparkly/testing.py
+++ b/sparkly/testing.py
@@ -656,7 +656,7 @@ class ElasticFixture(Fixture):
            ...
     """
 
-    def __init__(self, host, es_index, es_type, mapping=None, data=None, port=None):
+    def __init__(self, host, es_index, es_type=None, mapping=None, data=None, port=None):
         self.host = host
         self.port = port or 9200
         self.es_index = es_index
@@ -680,7 +680,7 @@ class ElasticFixture(Fixture):
             )
             self._request(
                 'PUT',
-                '/{}/_mapping/{}'.format(self.es_index, self.es_type),
+                '/{}/_mapping/{}'.format(self.es_index, self.es_type or ''),
                 self.read_file(self.mapping),
             )
 

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -25,7 +25,7 @@ from sparkly.utils import absolute_path
 class SparklyTestSession(SparklySession):
     packages = [
         'datastax:spark-cassandra-connector:2.4.0-s_2.11',
-        'org.elasticsearch:elasticsearch-spark-20_2.11:6.5.4',
+        'org.elasticsearch:elasticsearch-spark-20_2.11:7.3.0',
         'org.apache.spark:spark-streaming-kafka-0-8_2.11:2.4.0',
         'mysql:mysql-connector-java:6.0.6',
         'io.confluent:kafka-avro-serializer:3.0.1',
@@ -43,3 +43,13 @@ class SparklyTestSession(SparklySession):
         'collect_max': 'brickhouse.udf.collect.CollectMaxUDAF',
         'length_of_text': (lambda text: len(text), StringType())
     }
+
+
+class SparklyTestSessionWithES6(SparklySession):
+    packages = [
+        'org.elasticsearch:elasticsearch-spark-20_2.11:6.5.4',
+    ]
+
+    repositories = [
+        'http://packages.confluent.io/maven/',
+    ]

--- a/tests/integration/resources/test_fixtures/data_for_es7.json
+++ b/tests/integration/resources/test_fixtures/data_for_es7.json
@@ -1,0 +1,2 @@
+{ "index" : { "_index" : "sparkly_test_fixture", "_id": "1" } }
+{ "name" : "John", "age": 56}

--- a/tests/integration/resources/test_read/elastic7_setup.json
+++ b/tests/integration/resources/test_read/elastic7_setup.json
@@ -1,0 +1,6 @@
+{ "index" : { "_index" : "sparkly_test", "_id": "1" } }
+{ "name" : "John2", "topics": [1, 2, 3, 4, 5], "age": 56, "demo": { "age_30": 20, "age_10": 50 } }
+{ "index" : { "_index" : "sparkly_test", "_id": "2" } }
+{ "name" : "Smith3", "topics": [1, 4, 5], "age": 31, "demo": { "age_30": 110, "age_10": 50 } }
+{ "index" : { "_index" : "sparkly_test", "_id": "3" } }
+{ "name" : "Smith4", "topics": [4, 5], "age": 12, "demo": { "age_30": 20, "age_10": 1 } }

--- a/tests/integration/resources/test_write/elastic7_setup.json
+++ b/tests/integration/resources/test_write/elastic7_setup.json
@@ -1,0 +1,2 @@
+{ "index" : { "_index" : "sparkly_test", "_id": "1111" } }
+{ "uid": "1111", "title": "xxxx", "views": 1111}

--- a/tests/integration/test_testing.py
+++ b/tests/integration/test_testing.py
@@ -28,7 +28,11 @@ from sparkly.testing import (
     KafkaFixture,
     KafkaWatcher)
 from sparkly.utils import absolute_path
-from tests.integration.base import SparklyTestSession
+from tests.integration.base import (
+    SparklyTestSession,
+    SparklyTestSessionWithES6,
+)
+
 
 try:
     from kafka import KafkaConsumer, KafkaProducer
@@ -119,13 +123,13 @@ class TestMysqlFixtures(SparklyGlobalSessionTest):
         ])
 
 
-class TestElasticFixture(SparklyGlobalSessionTest):
+class TestElastic6Fixture(SparklyTest):
 
-    session = SparklyTestSession
+    session = SparklyTestSessionWithES6
 
     class_fixtures = [
         ElasticFixture(
-            'elastic.docker',
+            'elastic6.docker',
             'sparkly_test_fixture',
             'test',
             absolute_path(__file__, 'resources', 'test_fixtures', 'mapping.json'),
@@ -134,11 +138,33 @@ class TestElasticFixture(SparklyGlobalSessionTest):
     ]
 
     def test_elastic_fixture(self):
-        df = self.spark.read_ext.by_url('elastic://elastic.docker/sparkly_test_fixture/test?'
-                                     'es.read.metadata=false')
+        df = self.spark.read_ext.by_url(
+            'elastic://elastic6.docker/sparkly_test_fixture/test?es.read.metadata=false'
+        )
         self.assertDataFrameEqual(df, [
             {'name': 'John', 'age': 56},
         ])
+
+
+class TestElastic7Fixture(SparklyGlobalSessionTest):
+
+    session = SparklyTestSession
+
+    class_fixtures = [
+        ElasticFixture(
+            'elastic7.docker',
+            'sparkly_test_fixture',
+            None,
+            absolute_path(__file__, 'resources', 'test_fixtures', 'mapping.json'),
+            absolute_path(__file__, 'resources', 'test_fixtures', 'data_for_es7.json'),
+        )
+    ]
+
+    def test_elastic_fixture(self):
+        df = self.spark.read_ext.by_url(
+            'elastic://elastic7.docker/sparkly_test_fixture?es.read.metadata=false'
+        )
+        self.assertDataFrameEqual(df, [{'name': 'John', 'age': 56}])
 
 
 class TestKafkaFixture(SparklyGlobalSessionTest):

--- a/tests/unit/test_reader.py
+++ b/tests/unit/test_reader.py
@@ -77,7 +77,7 @@ class TestSparklyReaderByUrl(unittest.TestCase):
             header='false',
         )
 
-    def test_elastic(self):
+    def test_elastic_on_or_before_6(self):
         self.read_ext.elastic = mock.Mock(return_value=self.fake_df)
 
         df = self.read_ext.by_url('elastic://es_host/test_index/test_type?'
@@ -89,6 +89,25 @@ class TestSparklyReaderByUrl(unittest.TestCase):
             host='es_host',
             es_index='test_index',
             es_type='test_type',
+            query='?q=name:*Johnny*',
+            fields=['name', 'surname'],
+            port=None,
+            parallelism=4,
+            options={'es.input.json': 'true'},
+        )
+
+    def test_elastic_on_and_after_7(self):
+        self.read_ext.elastic = mock.Mock(return_value=self.fake_df)
+
+        df = self.read_ext.by_url('elastic://es_host/test_index?'
+                                  'q=name:*Johnny*&fields=name,surname&'
+                                  'es.input.json=true&parallelism=4')
+
+        self.assertEqual(df, self.fake_df)
+        self.read_ext.elastic.assert_called_with(
+            host='es_host',
+            es_index='test_index',
+            es_type=None,
             query='?q=name:*Johnny*',
             fields=['name', 'surname'],
             port=None,

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -263,3 +263,17 @@ class TestSparklySession(unittest.TestCase):
         original_session = _Session()
         retrieved_session = SparklySession.get_or_create()
         self.assertEqual(id(retrieved_session), id(original_session))
+
+    @mock.patch('sparkly.session.os')
+    @mock.patch('sparkly.session.SparkSession')
+    def test_stop_restores_the_environment(self, spark_session_mock, os_mock):
+        os_mock.environ = {
+            'PYSPARK_SUBMIT_ARGS': '--conf "my.conf.here=5g" --and-other-properties',
+        }
+
+        SparklySession()
+        SparklySession.stop()
+
+        self.assertEqual(os_mock.environ, {
+            'PYSPARK_SUBMIT_ARGS': '--conf "my.conf.here=5g" --and-other-properties',
+        })

--- a/tests/unit/test_writer.py
+++ b/tests/unit/test_writer.py
@@ -95,7 +95,7 @@ class TestWriteByUrl(unittest.TestCase):
             options={},
         )
 
-    def test_elastic(self):
+    def test_elastic_on_or_before_6(self):
         self.write_ext.elastic = mock.Mock()
 
         self.write_ext.by_url('elastic://host/index/type?parallelism=15')
@@ -109,7 +109,22 @@ class TestWriteByUrl(unittest.TestCase):
             parallelism=15,
             options={},
         )
+    
+    def test_elastic_on_and_after_7(self):
+        self.write_ext.elastic = mock.Mock()
 
+        self.write_ext.by_url('elastic://host/index?parallelism=15')
+
+        self.write_ext.elastic.assert_called_once_with(
+            host='host',
+            es_index='index',
+            es_type=None,
+            port=None,
+            mode=None,
+            parallelism=15,
+            options={},
+        )
+    
     def test_mysql(self):
         self.write_ext.mysql = mock.Mock()
 


### PR DESCRIPTION
Make the type optional when reading and writing to ElasticSearch and allow multiple sparkly sessions during tests.