### PR TITLE
IMP performance and environment improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.9.0
+* Improved performance of `catalog_ext.has_table` function by trying to execute a dummy SQL rather than listing the entire database, noticable mostly with databases with many tables.
+* Some minor changes to help in a spark-on-kubernetes environment:
+    * In addition to setting `PYSPARK_SUBMIT_ARGS`, also explicitly set config params so they are picked up by an already-running JVM
+    * Register a handler to stop spark session on python termination to deal with [SPARK-27927](https://issues.apache.org/jira/browse/SPARK-27927)
+
 ## 2.8.2
 * Support 0.9.x `pymysql` in `sparkly.testing.MysqlFixture`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Some minor changes to help in a spark-on-kubernetes environment:
     * In addition to setting `PYSPARK_SUBMIT_ARGS`, also explicitly set config params so they are picked up by an already-running JVM
     * Register a handler to stop spark session on python termination to deal with [SPARK-27927](https://issues.apache.org/jira/browse/SPARK-27927)
+* Removed `has_package` and `has_jar` functions, which are incomplete checks (resulting in false negatives) and are merely syntactic sugar.
 
 ## 2.8.2
 * Support 0.9.x `pymysql` in `sparkly.testing.MysqlFixture`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.9.0
+## 3.0.0
 * Improved performance of `catalog_ext.has_table` function by trying to execute a dummy SQL rather than listing the entire database, noticable mostly with databases with many tables.
 * Some minor changes to help in a spark-on-kubernetes environment:
     * In addition to setting `PYSPARK_SUBMIT_ARGS`, also explicitly set config params so they are picked up by an already-running JVM

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,7 @@ services:
       retries: 20
 
   mysql.docker:
-    image: mysql:5.7
+    image: mysql:5.7.11
     environment:
       MYSQL_DATABASE: sparkly_test
       MYSQL_USER: root

--- a/sparkly/__init__.py
+++ b/sparkly/__init__.py
@@ -19,4 +19,4 @@ from sparkly.session import SparklySession
 assert SparklySession
 
 
-__version__ = '2.8.2'
+__version__ = '2.9.0'

--- a/sparkly/__init__.py
+++ b/sparkly/__init__.py
@@ -19,4 +19,4 @@ from sparkly.session import SparklySession
 assert SparklySession
 
 
-__version__ = '2.9.0'
+__version__ = '3.0.0.dev1'

--- a/sparkly/catalog.py
+++ b/sparkly/catalog.py
@@ -16,6 +16,7 @@
 import uuid
 
 from pyspark.sql import functions as F
+from pyspark.sql import utils as U
 
 
 class SparklyCatalog(object):
@@ -116,17 +117,13 @@ class SparklyCatalog(object):
         Returns:
             bool
         """
-        db_name = get_db_name(table_name)
-        rel_table_name = get_table_name(table_name)
 
-        if not self.has_database(db_name):
+        try:
+            self._spark.sql('SELECT 1 FROM {} WHERE 1=0'.format(table_name))
+        except U.AnalysisException:
             return False
 
-        for table in self._spark.catalog.listTables(db_name):
-            if table.name == rel_table_name:
-                return True
-
-        return False
+        return True
 
     def has_database(self, db_name):
         """Check if database exists in the metastore.

--- a/sparkly/reader.py
+++ b/sparkly/reader.py
@@ -125,8 +125,6 @@ class SparklyReader(object):
         Returns:
             pyspark.sql.DataFrame
         """
-        assert self._spark.has_package('datastax:spark-cassandra-connector')
-
         reader_options = {
             'format': 'org.apache.spark.sql.cassandra',
             'spark.cassandra.connection.host': host,
@@ -161,8 +159,6 @@ class SparklyReader(object):
         Returns:
             pyspark.sql.DataFrame
         """
-        assert self._spark.has_package('org.elasticsearch:elasticsearch-spark')
-
         reader_options = {
             'path': '{}/{}'.format(es_index, es_type) if es_type else es_index,
             'format': 'org.elasticsearch.spark.sql',
@@ -197,9 +193,6 @@ class SparklyReader(object):
         Returns:
             pyspark.sql.DataFrame
         """
-        assert (self._spark.has_jar('mysql-connector-java') or
-                self._spark.has_package('mysql:mysql-connector-java'))
-
         reader_options = {
             'format': 'jdbc',
             'driver': 'com.mysql.jdbc.Driver',
@@ -254,8 +247,6 @@ class SparklyReader(object):
         Raises:
             InvalidArgumentError
         """
-        assert self._spark.has_package('org.apache.spark:spark-streaming-kafka')
-
         if not key_deserializer or not value_deserializer or not schema:
             raise InvalidArgumentError('You should specify all of parameters:'
                                        '`key_deserializer`, `value_deserializer` and `schema`')

--- a/sparkly/session.py
+++ b/sparkly/session.py
@@ -170,28 +170,6 @@ class SparklySession(SparkSession):
             'Please, follow the documentation for more details.'
         )
 
-    def has_package(self, package_prefix):
-        """Check if the package is available in the session.
-
-        Args:
-            package_prefix (str): E.g. "org.elasticsearch:elasticsearch-spark".
-
-        Returns:
-            bool
-        """
-        return any(package for package in self.packages if package.startswith(package_prefix))
-
-    def has_jar(self, jar_name):
-        """Check if the jar is available in the session.
-
-        Args:
-            jar_name (str): E.g. "mysql-connector-java".
-
-        Returns:
-            bool
-        """
-        return any(jar for jar in self.jars if jar_name in jar)
-
     def _setup_repositories(self):
         if self.repositories:
             return '--repositories {}'.format(','.join(self.repositories))

--- a/sparkly/testing.py
+++ b/sparkly/testing.py
@@ -90,6 +90,7 @@ def _ensure_gateway_is_down():
     )
     SparkContext._gateway.shutdown()
     SparkContext._gateway = None
+    SparkContext._jvm = None
     os.kill(jvm_pid, signal.SIGKILL)
     os.environ.pop('PYSPARK_GATEWAY_PORT', None)
     os.environ.pop('PYSPARK_GATEWAY_SECRET', None)
@@ -133,6 +134,9 @@ class SparklyTest(TestCase):
 
             # Reduce number of shuffle partitions (faster tests).
             'spark.sql.shuffle.partitions': '4',
+
+            # test overwriting of options
+            'my.custom.option.3': 333,
         })
 
     @classmethod

--- a/sparkly/writer.py
+++ b/sparkly/writer.py
@@ -138,8 +138,6 @@ class SparklyWriter(object):
             options (dict[str, str]): Additional options to `org.apache.spark.sql.cassandra`
                 format (see configuration for :ref:`cassandra`).
         """
-        assert self._spark.has_package('datastax:spark-cassandra-connector')
-
         writer_options = {
             'format': 'org.apache.spark.sql.cassandra',
             'spark.cassandra.connection.host': host,
@@ -171,8 +169,6 @@ class SparklyWriter(object):
             options (dict[str, str]): Additional options to `org.elasticsearch.spark.sql` format
                 (see configuration for :ref:`elastic`).
         """
-        assert self._spark.has_package('org.elasticsearch:elasticsearch-spark')
-
         writer_options = {
             'path': '{}/{}'.format(es_index, es_type) if es_type else es_index,
             'format': 'org.elasticsearch.spark.sql',
@@ -200,9 +196,6 @@ class SparklyWriter(object):
             options (dict): Additional options for JDBC writer
                 (see configuration for :ref:`mysql`).
         """
-        assert (self._spark.has_jar('mysql-connector-java') or
-                self._spark.has_package('mysql:mysql-connector-java'))
-
         writer_options = {
             'format': 'jdbc',
             'driver': 'com.mysql.jdbc.Driver',
@@ -246,8 +239,6 @@ class SparklyWriter(object):
                 during the write stage (see :ref:`controlling-the-load`).
             options (dict|None): Additional options.
         """
-        assert self._spark.has_package('org.apache.spark:spark-streaming-kafka')
-
         if not KAFKA_WRITER_SUPPORT:
             raise NotImplementedError('kafka-python package isn\'t available. '
                                       'Use pip install sparkly[kafka] to fix it.')

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -44,6 +44,13 @@ class SparklyTestSession(SparklySession):
         'length_of_text': (lambda text: len(text), StringType())
     }
 
+    options = {
+        'my.custom.option.1': '117',
+        'my.custom.option.2': 223,
+        # will be overwritten by additional_options passed in setup_session
+        'my.custom.option.3': '319',
+    }
+
 
 class SparklyTestSessionWithES6(SparklySession):
     packages = [

--- a/tests/integration/test_session.py
+++ b/tests/integration/test_session.py
@@ -21,6 +21,12 @@ from tests.integration.base import SparklyTestSession
 class TestSparklySession(SparklyGlobalSessionTest):
     session = SparklyTestSession
 
+    def test_options(self):
+        self.assertEqual('hive', self.spark.conf.get('spark.sql.catalogImplementation'))
+        self.assertEqual('117', self.spark.conf.get('my.custom.option.1'))
+        self.assertEqual('223', self.spark.conf.get('my.custom.option.2'))
+        self.assertEqual('333', self.spark.conf.get('my.custom.option.3'))
+
     def test_python_udf(self):
         rows = self.spark.sql('select length_of_text("hello world")')
         self.assertEqual(rows.collect()[0][0], '11')

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -43,20 +43,6 @@ class TestSparklySession(unittest.TestCase):
         [p.stop() for p in self.patches]
         super(TestSparklySession, self).tearDown()
 
-    def test_has_package(self):
-        hc = SparklySession()
-        self.assertFalse(hc.has_package('datastax:spark-cassandra-connector'))
-
-        hc.packages = ['datastax:spark-cassandra-connector:1.6.1-s_2.10']
-        self.assertTrue(hc.has_package('datastax:spark-cassandra-connector'))
-
-    def test_has_jar(self):
-        hc = SparklySession()
-        self.assertFalse(hc.has_jar('mysql-connector-java'))
-
-        hc.jars = ['mysql-connector-java-5.1.39-bin.jar']
-        self.assertTrue(hc.has_jar('mysql-connector-java'))
-
     @mock.patch('sparkly.session.os')
     def test_session_with_packages(self, os_mock):
         os_mock.environ = {}


### PR DESCRIPTION
* improved performance for `catalog_ext.has_table`
* setting config through `SparkConf` object (in addition to current mechanism)
* registering an atexit handler to stop spark session prior to python
  termination to fix a pyspark issue on k8s where driver pod hangs
  (SPARK-27927)
* remove has_package and has_jar functions (breaking -> major version bump)