### PR TITLE
IMP add option to autogenerate spark app id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
     * In addition to setting `PYSPARK_SUBMIT_ARGS`, also explicitly set config params so they are picked up by an already-running JVM
     * Register a handler to stop spark session on python termination to deal with [SPARK-27927](https://issues.apache.org/jira/browse/SPARK-27927)
 * Removed `has_package` and `has_jar` functions, which are incomplete checks (resulting in false negatives) and are merely syntactic sugar.
+* Added options (class variables) `name` and `app_id_template` to autogenerate a unique value for
+  spark option `spark.app.id`, which can help to preserve spark history data for all sessions across restarts.
+  This functionality can be disabled by setting `app_id_template` to `None` or `''`.
 
 ## 2.8.2
 * Support 0.9.x `pymysql` in `sparkly.testing.MysqlFixture`

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,11 @@ RUN cd /usr/local && ln -s spark-2.4.0-bin-hadoop2.7 spark
 
 # Install Python development & testing utils
 RUN apt-get update && apt-get install -y python python-dev python3-pip
+# NOTE: the pip upgrade is required in order to resolve proper deps
+# for virtualenv, specifically that `importlib-resources-3.3.0` does
+# not support py35, and that 3.2.1 should be used instead.
+# also note that this must be done prior to any other pip installs.
+RUN python3 -m pip install --upgrade pip==20.2.4
 RUN python3 -m pip install tox==2.4.1
 
 # Remove noisy spark logging

--- a/sparkly/__init__.py
+++ b/sparkly/__init__.py
@@ -19,4 +19,4 @@ from sparkly.session import SparklySession
 assert SparklySession
 
 
-__version__ = '3.0.0.dev1'
+__version__ = '3.0.0'

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -43,8 +43,12 @@ class TestSparklySession(unittest.TestCase):
         [p.stop() for p in self.patches]
         super(TestSparklySession, self).tearDown()
 
+    @mock.patch('sparkly.session.time.time')
+    @mock.patch('sparkly.session.uuid.uuid4')
     @mock.patch('sparkly.session.os')
-    def test_session_with_packages(self, os_mock):
+    def test_session_with_packages(self, os_mock, uid_mock, time_mock):
+        time_mock.side_effect = [n * 111 for n in range(1, 20)]
+        uid_mock.side_effect = [mock.Mock(hex='uid{}'.format(n)) for n in range(1, 20)]
         os_mock.environ = {}
 
         class _Session(SparklySession):
@@ -56,13 +60,18 @@ class TestSparklySession(unittest.TestCase):
             'PYSPARK_PYTHON': sys.executable,
             'PYSPARK_SUBMIT_ARGS': (
                 '--packages package1,package2 '
+                '--conf "spark.app.id=sparkly-uid1-222" '
                 '--conf "spark.sql.catalogImplementation=hive" '
                 'pyspark-shell'
             ),
         })
 
+    @mock.patch('sparkly.session.time.time')
+    @mock.patch('sparkly.session.uuid.uuid4')
     @mock.patch('sparkly.session.os')
-    def test_session_with_repositories(self, os_mock):
+    def test_session_with_repositories(self, os_mock, uid_mock, time_mock):
+        time_mock.side_effect = [n * 111 for n in range(1, 20)]
+        uid_mock.side_effect = [mock.Mock(hex='uid{}'.format(n)) for n in range(1, 20)]
         os_mock.environ = {}
 
         class _Session(SparklySession):
@@ -79,13 +88,18 @@ class TestSparklySession(unittest.TestCase):
             'PYSPARK_SUBMIT_ARGS': (
                 '--repositories http://my.maven.repo,http://another.maven.repo '
                 '--packages package1,package2 '
+                '--conf "spark.app.id=sparkly-uid1-222" '
                 '--conf "spark.sql.catalogImplementation=hive" '
                 'pyspark-shell'
             ),
         })
 
+    @mock.patch('sparkly.session.time.time')
+    @mock.patch('sparkly.session.uuid.uuid4')
     @mock.patch('sparkly.session.os')
-    def test_session_with_jars(self, os_mock):
+    def test_session_with_jars(self, os_mock, uid_mock, time_mock):
+        time_mock.side_effect = [n * 111 for n in range(1, 20)]
+        uid_mock.side_effect = [mock.Mock(hex='uid{}'.format(n)) for n in range(1, 20)]
         os_mock.environ = {}
 
         class _Session(SparklySession):
@@ -97,13 +111,18 @@ class TestSparklySession(unittest.TestCase):
             'PYSPARK_PYTHON': sys.executable,
             'PYSPARK_SUBMIT_ARGS': (
                 '--jars file_a.jar,file_b.jar '
+                '--conf "spark.app.id=sparkly-uid1-222" '
                 '--conf "spark.sql.catalogImplementation=hive" '
                 'pyspark-shell'
             ),
         })
 
+    @mock.patch('sparkly.session.time.time')
+    @mock.patch('sparkly.session.uuid.uuid4')
     @mock.patch('sparkly.session.os')
-    def test_session_with_options(self, os_mock):
+    def test_session_with_options(self, os_mock, uid_mock, time_mock):
+        time_mock.side_effect = [n * 111 for n in range(1, 20)]
+        uid_mock.side_effect = [mock.Mock(hex='uid{}'.format(n)) for n in range(1, 20)]
         os_mock.environ = {}
 
         # test options attached to class definition
@@ -118,6 +137,7 @@ class TestSparklySession(unittest.TestCase):
         self.assertEqual(os_mock.environ, {
             'PYSPARK_PYTHON': sys.executable,
             'PYSPARK_SUBMIT_ARGS': (
+                '--conf "spark.app.id=sparkly-uid1-222" '
                 '--conf "spark.option.a=value_a" '
                 '--conf "spark.option.b=value_b" '
                 '--conf "spark.sql.catalogImplementation=hive" '
@@ -136,6 +156,7 @@ class TestSparklySession(unittest.TestCase):
         self.assertEqual(os_mock.environ, {
             'PYSPARK_PYTHON': sys.executable,
             'PYSPARK_SUBMIT_ARGS': (
+                '--conf "spark.app.id=sparkly-uid3-444" '
                 '--conf "spark.option.a=value_a" '
                 '--conf "spark.option.b=value_0" '
                 '--conf "spark.option.c=value_c" '
@@ -156,26 +177,40 @@ class TestSparklySession(unittest.TestCase):
         self.assertEqual(os_mock.environ, {
             'PYSPARK_PYTHON': sys.executable,
             'PYSPARK_SUBMIT_ARGS': (
+                '--conf "spark.app.id=sparkly-uid5-666" '
                 '--conf "spark.sql.catalogImplementation=my_fancy_catalog" '
                 'pyspark-shell'
             ),
         })
 
+    @mock.patch('sparkly.session.time.time')
+    @mock.patch('sparkly.session.uuid.uuid4')
     @mock.patch('sparkly.session.os')
-    def test_session_without_packages_jars_and_options(self, os_mock):
+    def test_session_without_packages_jars_and_options(self, os_mock, uid_mock, time_mock):
+        time_mock.side_effect = [n * 111 for n in range(1, 20)]
+        uid_mock.side_effect = [mock.Mock(hex='uid{}'.format(n)) for n in range(1, 20)]
         os_mock.environ = {}
 
         SparklySession()
 
         self.assertEqual(os_mock.environ, {
             'PYSPARK_PYTHON': sys.executable,
-            'PYSPARK_SUBMIT_ARGS': '--conf "spark.sql.catalogImplementation=hive" pyspark-shell',
+            'PYSPARK_SUBMIT_ARGS': (
+                '--conf "spark.app.id=sparkly-uid1-222" '
+                '--conf "spark.sql.catalogImplementation=hive" pyspark-shell'
+            ),
         })
 
+    @mock.patch('sparkly.session.time.time')
+    @mock.patch('sparkly.session.uuid.uuid4')
     @mock.patch('sparkly.session.os')
-    def test_session_appends_to_pyspark_submit_args(self, os_mock):
+    def test_session_appends_to_pyspark_submit_args(self, os_mock, uid_mock, time_mock):
+        time_mock.side_effect = [n * 111 for n in range(1, 20)]
+        uid_mock.side_effect = [mock.Mock(hex='uid{}'.format(n)) for n in range(1, 20)]
         os_mock.environ = {
-            'PYSPARK_SUBMIT_ARGS': '--conf "my.conf.here=5g" --and-other-properties',
+            'PYSPARK_SUBMIT_ARGS': (
+                '--conf "my.conf.here=5g" --and-other-properties'
+            )
         }
 
         SparklySession()
@@ -184,6 +219,7 @@ class TestSparklySession(unittest.TestCase):
             'PYSPARK_PYTHON': sys.executable,
             'PYSPARK_SUBMIT_ARGS': (
                 '--conf "my.conf.here=5g" --and-other-properties '
+                '--conf "spark.app.id=sparkly-uid1-222" '
                 '--conf "spark.sql.catalogImplementation=hive" '
                 'pyspark-shell'
             ),
@@ -191,7 +227,9 @@ class TestSparklySession(unittest.TestCase):
 
         # test more complicated session
         os_mock.environ = {
-            'PYSPARK_SUBMIT_ARGS': '--conf "my.conf.here=5g" --and-other-properties',
+            'PYSPARK_SUBMIT_ARGS': (
+                '--conf "my.conf.here=5g" --and-other-properties'
+            ),
         }
 
         class _Session(SparklySession):
@@ -206,6 +244,7 @@ class TestSparklySession(unittest.TestCase):
                 # Note that spark honors the first conf it sees when multiple
                 # are defined
                 '--conf "my.conf.here=10g" '
+                '--conf "spark.app.id=sparkly-uid3-444" '
                 '--conf "spark.sql.catalogImplementation=hive" '
                 'pyspark-shell'
             ),
@@ -219,8 +258,12 @@ class TestSparklySession(unittest.TestCase):
 
         self.assertRaises(NotImplementedError, _Session)
 
+    @mock.patch('sparkly.session.time.time')
+    @mock.patch('sparkly.session.uuid.uuid4')
     @mock.patch('sparkly.session.SparkSession')
-    def test_get_or_create_and_stop(self, spark_session_mock):
+    def test_get_or_create_and_stop(self, spark_session_mock, uid_mock, time_mock):
+        time_mock.side_effect = [n * 111 for n in range(1, 20)]
+        uid_mock.side_effect = [mock.Mock(hex='uid{}'.format(n)) for n in range(1, 20)]
         # Not a great practice to test two functions in one unit test,
         # but get_or_create and stop are kind of intertwined with each other
 
@@ -250,16 +293,166 @@ class TestSparklySession(unittest.TestCase):
         retrieved_session = SparklySession.get_or_create()
         self.assertEqual(id(retrieved_session), id(original_session))
 
+    @mock.patch('sparkly.session.time.time')
+    @mock.patch('sparkly.session.uuid.uuid4')
     @mock.patch('sparkly.session.os')
     @mock.patch('sparkly.session.SparkSession')
-    def test_stop_restores_the_environment(self, spark_session_mock, os_mock):
+    def test_stop_restores_the_environment(self, spark_session_mock, os_mock, uid_mock, time_mock):
+        time_mock.side_effect = [n * 111 for n in range(1, 20)]
+        uid_mock.side_effect = [mock.Mock(hex='uid{}'.format(n)) for n in range(1, 20)]
         os_mock.environ = {
-            'PYSPARK_SUBMIT_ARGS': '--conf "my.conf.here=5g" --and-other-properties',
+            'PYSPARK_SUBMIT_ARGS': (
+                '--conf "spark.app.id=sparkly-uid1-222" '
+                '--conf "my.conf.here=5g" --and-other-properties'
+            ),
         }
 
         SparklySession()
         SparklySession.stop()
 
         self.assertEqual(os_mock.environ, {
-            'PYSPARK_SUBMIT_ARGS': '--conf "my.conf.here=5g" --and-other-properties',
+            'PYSPARK_SUBMIT_ARGS': (
+                '--conf "spark.app.id=sparkly-uid1-222" '
+                '--conf "my.conf.here=5g" --and-other-properties'
+            ),
+        })
+
+    @mock.patch('sparkly.session.time.time')
+    @mock.patch('sparkly.session.uuid.uuid4')
+    @mock.patch('sparkly.session.os')
+    def test_session_custom_name(self, os_mock, uid_mock, time_mock):
+        time_mock.side_effect = [n * 111 for n in range(1, 20)]
+        uid_mock.side_effect = [mock.Mock(hex='uid{}'.format(n)) for n in range(1, 20)]
+        os_mock.environ = {}
+
+        class Session(SparklySession):
+            name = 'test_custom'
+
+        Session()
+
+        self.assertEqual(os_mock.environ, {
+            'PYSPARK_PYTHON': sys.executable,
+            'PYSPARK_SUBMIT_ARGS': (
+                '--conf "spark.app.id=test_custom-uid1-222" '
+                '--conf "spark.sql.catalogImplementation=hive" '
+                'pyspark-shell'
+            ),
+        })
+
+    @mock.patch('sparkly.session.time.time')
+    @mock.patch('sparkly.session.uuid.uuid4')
+    @mock.patch('sparkly.session.os')
+    def test_session_null_app_id_template(self, os_mock, uid_mock, time_mock):
+        time_mock.side_effect = [n * 111 for n in range(1, 20)]
+        uid_mock.side_effect = [mock.Mock(hex='uid{}'.format(n)) for n in range(1, 20)]
+        os_mock.environ = {}
+
+        class Session(SparklySession):
+            app_id_template = None
+
+        Session()
+
+        self.assertEqual(os_mock.environ, {
+            'PYSPARK_PYTHON': sys.executable,
+            'PYSPARK_SUBMIT_ARGS': (
+                # MISSING: '--conf "spark.app.id=sparkly-uid1-222" '
+                '--conf "spark.sql.catalogImplementation=hive" '
+                'pyspark-shell'
+            ),
+        })
+
+    @mock.patch('sparkly.session.time.time')
+    @mock.patch('sparkly.session.uuid.uuid4')
+    @mock.patch('sparkly.session.os')
+    def test_session_empty_app_id_template(self, os_mock, uid_mock, time_mock):
+        time_mock.side_effect = [n * 111 for n in range(1, 20)]
+        uid_mock.side_effect = [mock.Mock(hex='uid{}'.format(n)) for n in range(1, 20)]
+        os_mock.environ = {}
+
+        class Session(SparklySession):
+            app_id_template = ''
+
+        Session()
+
+        self.assertEqual(os_mock.environ, {
+            'PYSPARK_PYTHON': sys.executable,
+            'PYSPARK_SUBMIT_ARGS': (
+                # MISSING: '--conf "spark.app.id=sparkly-uid1-222" '
+                '--conf "spark.sql.catalogImplementation=hive" '
+                'pyspark-shell'
+            ),
+        })
+
+    @mock.patch('sparkly.session.time.time')
+    @mock.patch('sparkly.session.uuid.uuid4')
+    @mock.patch('sparkly.session.os')
+    def test_session_custom_app_id_template(self, os_mock, uid_mock, time_mock):
+        time_mock.side_effect = [n * 111 for n in range(1, 20)]
+        uid_mock.side_effect = [mock.Mock(hex='uid{}'.format(n)) for n in range(1, 20)]
+        os_mock.environ = {}
+
+        class Session(SparklySession):
+            app_id_template = 'my_custom-{initial_uid}-{session_uid}-{initial_time}-{session_time}'
+
+        Session()
+
+        self.assertEqual(os_mock.environ, {
+            'PYSPARK_PYTHON': sys.executable,
+            'PYSPARK_SUBMIT_ARGS': (
+                '--conf "spark.app.id=my_custom-uid1-uid2-111-222" '
+                '--conf "spark.sql.catalogImplementation=hive" '
+                'pyspark-shell'
+            ),
+        })
+
+    @mock.patch('sparkly.session.time.time')
+    @mock.patch('sparkly.session.uuid.uuid4')
+    @mock.patch('sparkly.session.os')
+    def test_session_app_id_override_1(self, os_mock, uid_mock, time_mock):
+        time_mock.side_effect = [n * 111 for n in range(1, 20)]
+        uid_mock.side_effect = [mock.Mock(hex='uid{}'.format(n)) for n in range(1, 20)]
+        os_mock.environ = {}
+
+        class Session(SparklySession):
+            # kind of silly setup here, but to demonstrate which one wins..
+            app_id_template = 'my_custom-{initial_uid}-{session_time}'
+            options = {
+                'spark.app.id': 'this-overrides-the-template',
+            }
+
+        Session()
+
+        self.assertEqual(os_mock.environ, {
+            'PYSPARK_PYTHON': sys.executable,
+            'PYSPARK_SUBMIT_ARGS': (
+                '--conf "spark.app.id=this-overrides-the-template" '
+                '--conf "spark.sql.catalogImplementation=hive" '
+                'pyspark-shell'
+            ),
+        })
+
+    @mock.patch('sparkly.session.time.time')
+    @mock.patch('sparkly.session.uuid.uuid4')
+    @mock.patch('sparkly.session.os')
+    def test_session_app_id_override_2(self, os_mock, uid_mock, time_mock):
+        time_mock.side_effect = [n * 111 for n in range(1, 20)]
+        uid_mock.side_effect = [mock.Mock(hex='uid{}'.format(n)) for n in range(1, 20)]
+        os_mock.environ = {}
+
+        class Session(SparklySession):
+            app_id_template = 'my_custom-{initial_uid}-{session_time}'
+
+        # sort of a more "realistic" use case where some additional options
+        # are passed at construction time, we can still override the spark app id
+        Session({
+            'spark.app.id': 'this-overrides-the-template',
+        })
+
+        self.assertEqual(os_mock.environ, {
+            'PYSPARK_PYTHON': sys.executable,
+            'PYSPARK_SUBMIT_ARGS': (
+                '--conf "spark.app.id=this-overrides-the-template" '
+                '--conf "spark.sql.catalogImplementation=hive" '
+                'pyspark-shell'
+            ),
         })


### PR DESCRIPTION
Specifically to help with maintaining spark history across session
restarts in Kubernetes