### PR TITLE
FIX return false for has empty table

### DIFF
--- a/sparkly/catalog.py
+++ b/sparkly/catalog.py
@@ -118,6 +118,9 @@ class SparklyCatalog(object):
             bool
         """
 
+        if not table_name:
+            return False
+
         try:
             self._spark.sql('SELECT 1 FROM {} WHERE 1=0'.format(table_name))
         except U.AnalysisException:

--- a/tests/integration/test_catalog.py
+++ b/tests/integration/test_catalog.py
@@ -85,6 +85,8 @@ class TestSparklyCatalog(SparklyGlobalSessionTest):
         self.assertFalse(self.spark.catalog_ext.has_table('test_db.test_table'))
 
     def test_has_table(self):
+        self.assertFalse(self.spark.catalog_ext.has_table(None))
+        self.assertFalse(self.spark.catalog_ext.has_table(''))
         self.assertTrue(self.spark.catalog_ext.has_table('test_table'))
         self.assertTrue(self.spark.catalog_ext.has_table('test_db.test_table'))
         self.assertFalse(self.spark.catalog_ext.has_table('test_unknown_table'))


### PR DESCRIPTION
In 3.0.0, we optimized the `has_table` function to return much more quickly by running an SQL statement like `select 1 from <table> where 1=0`, and returning false on error, rather than listing the entire contents of the database.  However, it turns out that the following is legal syntax:

```
select 1 from  where 1=0
```

Which means that checking for an emptystring-tablename returns `True` where it should return `False` (this is not a legal table name, after all).

Added an explicit check.