### PR TITLE
Support both old and new catalog

### DIFF
--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -50,3 +50,9 @@ class SparklyTestSession(SparklySession):
         # will be overwritten by additional_options passed in setup_session
         'my.custom.option.3': '319',
     }
+
+
+class SparklyTestSessionWithOldCatalog(SparklyTestSession):
+    options = {
+        'spark.sql.legacy.keepCommandOutputSchema': 'true',
+    }

--- a/tests/integration/test_catalog.py
+++ b/tests/integration/test_catalog.py
@@ -15,7 +15,7 @@
 #
 
 from sparkly.testing import SparklyGlobalSessionTest
-from tests.integration.base import SparklyTestSession
+from tests.integration.base import SparklyTestSession, SparklyTestSessionWithOldCatalog
 from sparkly.catalog import read_db_properties_format
 
 
@@ -197,3 +197,7 @@ class TestSparklyCatalog(SparklyGlobalSessionTest):
 
         with self.assertRaises(ValueError):
             read_db_properties_format(')')
+
+
+class TestSparklyWithOldCatalog(TestSparklyCatalog):
+    session = SparklyTestSessionWithOldCatalog


### PR DESCRIPTION
 In Spark 3.1 or earlier, the info_name field was named database_description_item and the info_value field was named database_description_value for the builtin catalog.