### PR TITLE
Fix for Dockerfile smell DL3009

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,9 @@ LABEL maintainer="dev@tubularlabs.com"
 # Install Java 8
 RUN apt-get update && apt-get install -y software-properties-common
 RUN apt-add-repository 'deb http://security.debian.org/debian-security stretch/updates main'
-RUN apt-get update && apt-get install -y openjdk-8-jdk
+RUN apt-get update && apt-get install -y openjdk-8-jdk \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # Python env
 ENV CASS_DRIVER_NO_EXTENSIONS=1


### PR DESCRIPTION
Hi!
The Dockerfile placed at "Dockerfile" contains the best practice violation [DL3009](https://github.com/hadolint/hadolint/wiki/DL3009) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3009 occurs when the apt tool is used to install packages without wiping the cache and source lists.
This pull request proposes a fix for that smell generated by my fixing tool. The generated patch has been manually verified before opening the pull request.
To fix this smell, specifically, the instructions to clean up the apt cache and remove the /var/lib/apt/lists have been added. This helps keep the image size down.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance