### PR TITLE
OPS-5046 support spark 3.4.0 on SPOK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ LABEL maintainer="dev@tubularlabs.com"
 # Install Java 8
 RUN apt-get update && apt-get install -y software-properties-common
 RUN apt-add-repository 'deb http://security.debian.org/debian-security stretch/updates main'
+RUN apt-add-repository 'deb http://deb.debian.org/debian/ sid main'
 RUN apt-get update && apt-get install -y openjdk-8-jdk
 
 # Python env

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -18,6 +18,7 @@ import os
 
 from pyspark.sql.types import StringType
 
+import pyspark 
 from sparkly import SparklySession
 from sparkly.utils import absolute_path
 
@@ -26,7 +27,7 @@ class SparklyTestSession(SparklySession):
     packages = [
         'com.datastax.spark:spark-cassandra-connector_2.12:3.2.0',
         'org.elasticsearch:elasticsearch-spark-30_2.12:7.17.8',
-        'org.apache.spark:spark-sql-kafka-0-10_2.12:3.3.1',
+        'org.apache.spark:spark-sql-kafka-0-10_2.12:{}'.format(pyspark.__version__),
         'mysql:mysql-connector-java:8.0.31',
         'io.confluent:kafka-avro-serializer:3.0.1',
     ]

--- a/tests/integration/test_catalog.py
+++ b/tests/integration/test_catalog.py
@@ -108,11 +108,11 @@ class TestSparklyCatalog(SparklyGlobalSessionTest):
         self.assertTrue(self.spark.catalog_ext.has_table('test_db.test_table'))
         self.assertFalse(self.spark.catalog_ext.has_table('test_db.new_test_table'))
 
-        self.spark.catalog_ext.rename_table('test_db.test_table', 'new_test_table')
+        self.spark.catalog_ext.rename_table('test_db.test_table', 'test_db.new_test_table')
 
         self.assertFalse(self.spark.catalog_ext.has_table('test_db.test_table'))
-        self.assertTrue(self.spark.catalog_ext.has_table('default.new_test_table'))
-        self.assertEqual(self.spark.table('default.new_test_table').count(), 2)
+        self.assertTrue(self.spark.catalog_ext.has_table('test_db.new_test_table'))
+        self.assertEqual(self.spark.table('test_db.new_test_table').count(), 2)
 
     def test_get_table_properties(self):
         properties = self.spark.catalog_ext.get_table_properties('test_table')

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@
 #
 
 [tox]
-envlist = spark32,spark33,no_extras,docs
+envlist = spark32,spark33,spark34,no_extras,docs
 
 [testenv:spark32]
 commands = py.test --cov=sparkly --cov-report term-missing tests/integration tests/unit
@@ -32,6 +32,14 @@ deps =
     -rrequirements_dev.txt
     -rrequirements_extras.txt
     pyspark==3.3.1
+
+[testenv:spark34]
+commands = py.test --cov=sparkly --cov-report term-missing tests/integration tests/unit
+deps =
+    -rrequirements.txt
+    -rrequirements_dev.txt
+    -rrequirements_extras.txt
+    pyspark==3.4.0
 
 [testenv:no_extras]
 commands = py.test tests/no_extras


### PR DESCRIPTION
spark 3.4.0 made a change to spark type `CharType` which requires the constructor to take a parameter `length` so we are using spark's internal method to take care of all that parsing